### PR TITLE
Adiciona template para Pull Request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+Close: *Adicione aqui o link para a issue que será resolvida com este PR.*
+
+## Motivação
+
+*Descreva as motivações deste PR*
+
+Exemplo:
+
+Tradução do tópico  **1 Guide Assumptions** da página **Getting Started with Rails**.
+
+## Comentários
+
+*Coloque comentários que considerar importante mencionar*
+
+Exemplo:
+
+https://guides.rubyonrails.org/getting_started.html#guide-assumptions
+
+Traduzi apenas o primeiro e o segundo parágrafo do tópico.


### PR DESCRIPTION
Issue: Nenhuma

## Motivação

Padronizar o template dos pull requests abertos para facilitar o *review*.

## Comentários

Coloquei o template em `.github/pull_request_template.md`
Vi que há um subdiretório para múltiplos templates de `issue`, mas não sei se para `pull request` devo adotar o mesmo padrão.

Como são `pull requests` em sua maioria para tradução, não coloquei uma seção `Proposta`, mas sim uma de `Comentários`.
