### PR TITLE
traduzindo i18n parte inicial

### DIFF
--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -1,33 +1,34 @@
 **NÃO LEIA ESTE ARQUIVO NO GITHUB, OS GUIAS SÃO PUBLICADOS NO https://guiarails.com.br.**
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
-Rails Internationalization (I18n) API
+API de Internacionalização do Rails (I18n)
 =====================================
 
-The Ruby I18n (shorthand for _internationalization_) gem which is shipped with Ruby on Rails (starting from Rails 2.2) provides an easy-to-use and extensible framework for **translating your application to a single custom language** other than English or for **providing multi-language support** in your application.
 
-The process of "internationalization" usually means to abstract all strings and other locale specific bits (such as date or currency formats) out of your application. The process of "localization" means to provide translations and localized formats for these bits.[^1]
+Ruby I18n(abreviação de intercionalização) é um "gem" fornecida com o Ruby on Rails(a partir do Rails 2.2) que fornece uma estrutura extensível e fácil de usar para **traduzir sua aplicação para um único idioma personalizado** que não seja o inglês ou **para fornecer suporte em multi-linguagens** em sua aplicação.
 
-So, in the process of _internationalizing_ your Rails application you have to:
 
-* Ensure you have support for i18n.
-* Tell Rails where to find locale dictionaries.
-* Tell Rails how to set, preserve, and switch locales.
+O processo de "internacionalização" geralmente significa abstrair todas as strings e outros bits específicos do código do idioma(como formatos de data ou moeda) de sua aplicação. O processo de "localização" significa fornecer traduções e formatos locais para esses bits.
 
-In the process of _localizing_ your application you'll probably want to do the following three things:
 
-* Replace or supplement Rails' default locale - e.g. date and time formats, month names, Active Record model names, etc.
-* Abstract strings in your application into keyed dictionaries - e.g. flash messages, static text in your views, etc.
-* Store the resulting dictionaries somewhere.
+Portanto, no processo de intercionalização de sua aplicação Rails, você deve:
 
-This guide will walk you through the I18n API and contains a tutorial on how to internationalize a Rails application from the start.
+* Verifique se tem suporte para i18n.
+* Informe ao Rails onde encontrar dicionários locais.
+* Informe ao Rails como definir, preservar e alternar as localidades.
 
-After reading this guide, you will know:
+No processo de _localizing_ de sua aplicação, você provavelmente fará os três passos abaixo:
 
-* How I18n works in Ruby on Rails
-* How to correctly use I18n into a RESTful application in various ways
-* How to use I18n to translate Active Record errors or Action Mailer E-mail subjects
-* Some other tools to go further with the translation process of your application
+* Substituir ou complementar a localidade padrão do Rails - por exemplo formatos de data e hora, nomes de meses, nomes de modelos do Active Record, etc.
+* Abstrair strings em sua aplicação utilizando dicionários com chave - por exemplo mensagens flash, texto estático em suas visualizações etc.
+* Armazenar os dicionários resultantes em um lugar específico.
+
+Este documento o guiará pela API I18n e contém um tutorial sobre como internacionalizar um aplicativo Rails desde o início.
+
+* Como o I18n funciona no Ruby on Rail
+* Como usar corretamente o I18n em um aplicativo RESTful de várias maneiras
+* Como usar o I18n para traduzir erros do Active Record ou assuntos de email do Action Mailer
+* Algumas outras ferramentas para avançar no processo de tradução de sua aplicação.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Close: #216 

## Motivação

*Traduzir a introdução sobre internacionalização para facilitar o entendimento sobre o assunto*

## Comentários

*Foi traduzida a introdução da página Rails Internationalization (I18n) API*

Exemplo:

https://guides.rubyonrails.org/i18n.html

Traduzi apenas a introdução do tópico.
