### PR TITLE
Removendo cache do guia

### DIFF
--- a/pt-BR/layout.html.erb
+++ b/pt-BR/layout.html.erb
@@ -21,6 +21,9 @@
   <meta property="og:site_name" content="Guia Ruby on Rails" />
   <meta property="og:image" content="https://avatars.githubusercontent.com/u/4223" />
   <meta property="og:type" content="website" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
 </head>
 <body class="guide">
   <% if @edge %>


### PR DESCRIPTION
## Motivação

@campuscode/guia-rails-team imagino neste inicio devido a quantidade de deploys acontecendo devemos remover o cache do Guia momentaneamente.

## Comentários

Gostaria da opinião de vocês, caso seja aprovado vou criar uma issue para removermos estas linhas no futuro.