### PR TITLE
Correção de texto no TIP da home

### DIFF
--- a/pt-BR/index.html.erb
+++ b/pt-BR/index.html.erb
@@ -12,7 +12,7 @@
     <% unless @edge -%>
       <dd class="kindle">O Guia Rails também está disponível para <%= link_to 'Kindle', @mobi %>.</dd>
     <% end -%>
-    <dd class="work-in-progress">Os guias marcados com este ícone estão sendo em processo de tradução no momento e não estarão disponíveis no menu. Embora ainda sejam úteis, podem conter informações incompletas e até erros. Você pode ajudar revendo-os e publicando comentários e correções.</dd>
+    <dd class="work-in-progress">Os guias marcados com este ícone estão em processo de tradução no momento e não estarão disponíveis no menu. Embora ainda sejam úteis, podem conter informações incompletas e até erros. Você pode ajudar revisando-os e publicando comentários e correções.</dd>
   </dl>
 </div>
 <% end %>


### PR DESCRIPTION
## Motivação

Há um `typo` no TIP box da home do Guia.

![Captura de tela de 2019-11-30 10-48-42](https://user-images.githubusercontent.com/31378037/69901339-02527280-135f-11ea-8d0a-9de6977f2387.png)

## Comentários

Fiz apenas uma pequena modificação removendo a palavra **"sendo"** do TIP e trocando a palavra **revendo-os** por **revisando-os**.