### PR TITLE
Corrige tradução

### DIFF
--- a/pt-BR/action_controller_overview.md
+++ b/pt-BR/action_controller_overview.md
@@ -600,8 +600,7 @@ Se você usar o *cookie* de armazenamento de sessão, isso também se aplicaria 
 Renderizando dados XML e JSON
 ---------------------------
 
-O *ActionController* faz com que renderizar dados `XML` ou `JSON` seja extremamente fácil. Se você gerou um *controller*
-usando o *scaffold*, será algo mais ou menos assim:
+O *ActionController* faz com que renderizar dados `XML` ou `JSON` seja extremamente fácil. Se você gerou um *controller* usando o *scaffold*, será algo mais ou menos assim:
 
 ```ruby
 class UsersController < ApplicationController
@@ -616,8 +615,7 @@ class UsersController < ApplicationController
 end
 ```
 
-Você pode observar que no código acima estamos usando `render xml: @users`, e não `render xml: @users.to_xml`. Se o objeto
-não é uma *String*, então o Rails automaticamente chama `to_xml` por nós.
+Você pode observar que no código acima estamos usando `render xml: @users`, e não `render xml: @users.to_xml`. Se o objeto não é uma *String*, então o Rails automaticamente chama `to_xml` por nós.
 
 Filters
 -------


### PR DESCRIPTION
# Motivação
No pull request #274 efetuamos a tradução da seção `Renderizando dados XML e JSON` do  `Active Controller`, porém, por um erro de interpretação de como o meu editor de texto apresentava as linhas, assumi que deveria quebrar algumas linhas que no final se tornaram desnecessárias. 

![image](https://user-images.githubusercontent.com/13919606/72275492-ce7c9500-360c-11ea-8ae4-72e1149dfb5d.png)

O resultado renderizado não é afetado pela forma como alterei, mas, para evitar problemas, pensei que seria uma boa idéia retornar o que eu havia separado para somente uma linha, deixando mais próximo do texto original. 

