### PR TITLE
Removendo WIP das páginas finalizadas

### DIFF
--- a/pt-BR/documents.yaml
+++ b/pt-BR/documents.yaml
@@ -5,7 +5,6 @@
       name: Começando com Rails
       url: getting_started.html
       description: Tudo o que você precisa saber para instalar o Rails e criar sua primeira aplicação.
-      work_in_progress: true
 -
   name: Models
   documents:
@@ -13,7 +12,6 @@
       name: Active Record Basics
       url: active_record_basics.html
       description: Este guia irá ajudá-lo a começar com models, persistência no banco de dados, e no padrão e biblioteca Active Record.
-      work_in_progress: true
     -
       name: Active Record Migrations
       url: active_record_migrations.html
@@ -56,7 +54,6 @@
       name: Layouts and Rendering in Rails
       url: layouts_and_rendering.html
       description: Este guia aborda os recursos básicos de layout do Action Controller e do Action View, incluindo renderização e redirecionamento, uso de blocos de content_for e como utilizar partials.
-      work_in_progress: true
     -
       name: Action View Form Helpers
       url: form_helpers.html


### PR DESCRIPTION
## Motivação

Remover o WIP das páginas que estão 100% finalizadas. 

## Comentários

@campuscode/guia-rails-team é importante fazer a revisão fina destas páginas para nivelar o estilo de tradução. Podemos fazer uma futura revisão