### PR TITLE
Upgrade do Guia para versão 6.0.2.2 do Rails

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.html linguist-language=Ruby
+*.erb linguist-language=Ruby
+*.css linguist-language=Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
+ruby '2.7.0'
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git"  }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,5 +71,8 @@ DEPENDENCIES
   sdoc (~> 1.0)
   w3c_validators
 
+RUBY VERSION
+   ruby 2.7.0p0
+
 BUNDLED WITH
-   1.17.2
+   2.1.2

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :guides do
     desc "Generate HTML guides"
     task :html do
       ENV["WARNINGS"] = "1" # authors can't disable this
-      ENV["RAILS_VERSION"] = "v6.0.2.1"
+      ENV["RAILS_VERSION"] = "v6.0.2.2"
       ENV["GUIDES_LANGUAGE"] = "pt-BR"
       system 'cp -r ./pt-BR rails/guides/source'
       ruby "-Eutf-8:utf-8", "rails/guides/rails_guides.rb"
@@ -40,7 +40,7 @@ namespace :guides do
         abort "Please install ImageMagick"
       end
       ENV["KINDLE"] = "1"
-      ENV["RAILS_VERSION"] = "5.2.2"
+      ENV["RAILS_VERSION"] = "v6.0.2.2"
       ENV["GUIDES_LANGUAGE"] = "pt-BR"
       # Rake::Task["guides:generate:html"].invoke
       system 'cp -r ./pt-BR rails/guides/source'


### PR DESCRIPTION
## Motivação

Fazer upgrade do Guia para a versão 6.0.2.2 do Rails.

## Comentários

- Troquei os arquivos `.html`, `.css` e `.erb` para Ruby no Github pro nosso repo constar como Ruby 😄 
- Forcei a versão do Ruby como `2.7.0` para mantermos o Gemfile atualizado