### PR TITLE
Arrumando links quebrados

### DIFF
--- a/pt-BR/active_record_migrations.md
+++ b/pt-BR/active_record_migrations.md
@@ -907,7 +907,7 @@ your database schema.
 It tends to be faster and less error prone to create a new instance of your
 application's database by loading the schema file via `rails db:schema:load`
 than it is to replay the entire migration history.
-[Old migrations](#old-migrations) may fail to apply correctly if those
+[*Migrations* Antigas](#migrations-antigas) may fail to apply correctly if those
 migrations use changing external dependencies or rely on application code which
 evolves separately from your migrations.
 

--- a/pt-BR/active_record_querying.md
+++ b/pt-BR/active_record_querying.md
@@ -1593,7 +1593,7 @@ which allow us to use multiple Active Record methods together in a simple and st
 
 You can chain methods in a statement when the previous method called returns an
 `ActiveRecord::Relation`, like `all`, `where`, and `joins`. Methods that return
-a single object (see [Retrieving a Single Object Section](#retrieving-a-single-object))
+a single object (see [a seção Retornando um Único Objeto](#retornando-um-unico-objeto))
 have to be at the end of the statement.
 
 There are some examples below. This guide won't cover all the possibilities, just a few as examples.

--- a/pt-BR/active_record_validations.md
+++ b/pt-BR/active_record_validations.md
@@ -242,7 +242,7 @@ end
 ```
 
 Nós vamos cobrir os erros das validações em maior detalhe na seção [Trabalhando com
-Erros de Validações](#trabalhando-com-erros-de-validações).
+Erros de Validações](#working-with-validation-errors).
 
 ### `errors.details`
 
@@ -261,7 +261,7 @@ end
 ```
 
 O uso de `details` juntamente com validadores é tratado na seção
-[Trabalhando com Erros de Validações](#trabalhando-com-erros-de-validações).
+[Trabalhando com Erros de Validações](#working-with-validation-errors).
 
 Helpers de Validação
 ------------------

--- a/pt-BR/association_basics.md
+++ b/pt-BR/association_basics.md
@@ -253,7 +253,7 @@ class CreateAppointments < ActiveRecord::Migration[5.0]
 end
 ```
 
-O conjunto da junção dos _models_ pode ser gerenciada através dos [métodos de associação `has_many`](#has-many-association-reference).
+O conjunto da junção dos _models_ pode ser gerenciada através dos [métodos de associação `has_many`](#referencia-da-associacao-has-many).
 Por exemplo, se você atribuir:
 
 ```ruby
@@ -1022,7 +1022,7 @@ end
 
 ##### `:polymorphic`
 
-Passar `true` para a opção `:polymorphic` indica que esta é uma associação polimórfica. Associações polimórficas foram discutidas com detalhes <a href="#polymorphic-associations">anteriormente neste guia</a>.
+Passar `true` para a opção `:polymorphic` indica que esta é uma associação polimórfica. Associações polimórficas foram discutidas com detalhes <a href="#associacoes-polimorficas">anteriormente neste guia</a>.
 
 ##### `:touch`
 
@@ -1250,7 +1250,7 @@ A associação `has_one` tem suporte para estas opções:
 
 ##### `:as`
 
-Configurar a opção `:as` indica que esta é uma associação polimórfica. Associações polimórficas foram discutidas com detalhes [anteriormente neste guia](#polymorphic-associations).
+Configurar a opção `:as` indica que esta é uma associação polimórfica. Associações polimórficas foram discutidas com detalhes [anteriormente neste guia](#associacoes-polimorficas).
 
 ##### `:autosave`
 
@@ -1337,7 +1337,7 @@ class DustJacket < ApplicationRecord; end
 
 ##### `:through`
 
-A opção `:through` específica um *model* de junção para realizar uma _query_ através dele. Associações `has_one :through` foram discutidas com detalhes [anteriormente neste guia](#the-has-one-through-association).
+A opção `:through` específica um *model* de junção para realizar uma _query_ através dele. Associações `has_one :through` foram discutidas com detalhes [anteriormente neste guia](#a-associacao-has-one-through).
 
 ##### `:touch`
 
@@ -1684,7 +1684,7 @@ A associação `has_many` tem suporte para estas opções:
 
 ##### `:as`
 
-Configurar a opção `:as` indica que esta é uma associação polimórfica, como discutido [anteriomente neste guia](#polymorphic-associations).
+Configurar a opção `:as` indica que esta é uma associação polimórfica, como discutido [anteriomente neste guia](#associacoes-polimorficas).
 
 ##### `:autosave`
 
@@ -1702,7 +1702,7 @@ end
 
 ##### `:counter_cache`
 
-Esta opção pode ser utilizada para configurar um `:counter_cache` personalizado. Você só precisa desta opção quando você personalizar o nome do seu `:counter_cache` na [associação belongs_to](#options-for-belongs-to).
+Esta opção pode ser utilizada para configurar um `:counter_cache` personalizado. Você só precisa desta opção quando você personalizar o nome do seu `:counter_cache` na [associação belongs_to](#opcoes-para-belongs-to).
 
 ##### `:dependent`
 
@@ -1785,7 +1785,7 @@ class Paperback < ApplicationRecord; end
 
 ##### `:through`
 
-A opção `:through` específica um *model* de junção para realizar uma _query_ através dele. Associações `has_many :through` fornecem uma maneira de implementar relações muitos-para-muitos, como discutido [anteriormente neste guia](#the-has-many-through-association).
+A opção `:through` específica um *model* de junção para realizar uma _query_ através dele. Associações `has_many :through` fornecem uma maneira de implementar relações muitos-para-muitos, como discutido [anteriormente neste guia](#a-associacao-has-many-through).
 
 ##### `:validate`
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -7,7 +7,7 @@ API de Internacionalização do Rails (I18n)
 
 Ruby I18n (abreviação de internacionalização) é uma *gem* fornecida com o Ruby on Rails (a partir do Rails 2.2) que fornece uma estrutura extensível e fácil de usar para **traduzir sua aplicação para um único idioma personalizado** que não seja o inglês ou **para fornecer suporte em multilinguagens** em sua aplicação.
 
-O processo de "internacionalização" geralmente significa abstrair todas as *strings* e outros *bits* específicos do código do idioma (como formatos de data ou moeda) de sua aplicação. O processo de "localização" significa fornecer traduções e formatos locais para esses *bits*.
+O processo de "internacionalização" geralmente significa abstrair todas as *strings* e outros *bits* específicos do código do idioma (como formatos de data ou moeda) de sua aplicação. O processo de "localização" significa fornecer traduções e formatos locais para esses *bits*.[^1]
 
 Portanto, no processo de internacionalização de sua aplicação Rails, você deve:
 

--- a/pt-BR/layouts_and_rendering.md
+++ b/pt-BR/layouts_and_rendering.md
@@ -736,7 +736,7 @@ Isso detectaria que não há livros com o ID especificado, define a variável de
 
 ### Usando `head` para criar respostas com apenas o cabeçalho (_Header-Only_)
 
-O método `head` pode ser usado para enviar respostas apenas com cabeçalhos para o navegador. O método `head` aceita um número ou símbolo (consulte [tabela de referência] (#a-opção-status)) representando um código de status HTTP. O argumento de _options_ é interpretado como um hash de nomes e valores de cabeçalho. Por exemplo, você pode retornar apenas um cabeçalho de erro:
+O método `head` pode ser usado para enviar respostas apenas com cabeçalhos para o navegador. O método `head` aceita um número ou símbolo (consulte [tabela de referência] (#a-opcao-status)) representando um código de status HTTP. O argumento de _options_ é interpretado como um hash de nomes e valores de cabeçalho. Por exemplo, você pode retornar apenas um cabeçalho de erro:
 
 ```ruby
 head :bad_request


### PR DESCRIPTION
## Motivação

Com as mudanças recentes que fizemos usando links com `parameterize` alguns links ficaram quebrados. Esse PR é para corrigir esses links.

## Comentários

Tinha um link numa região não traduzida, fiz a tradução desse pedacinho para facilitar ao próximo tradutor.