### PR TITLE
Bump rails to 6.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '2.7.0'
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git"  }
 
@@ -10,5 +9,5 @@ gem "sdoc", "~> 1.0"
 gem "redcarpet", "~> 3.2.3", platforms: :ruby
 gem "w3c_validators"
 gem "kindlerb", "~> 1.2.0"
-gem 'activesupport', '~> 6.0.2', '>= 6.0.2.2'
-gem 'actionpack', '~> 6.0.2', '>= 6.0.2.2'
+gem 'activesupport', '~> 6.0.3'
+gem 'actionpack', '~> 6.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (6.0.2.2)
-      actionview (= 6.0.2.2)
-      activesupport (= 6.0.2.2)
+    actionpack (6.0.3)
+      actionview (= 6.0.3)
+      activesupport (= 6.0.3)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.0.2.2)
-      activesupport (= 6.0.2.2)
+    actionview (6.0.3)
+      activesupport (= 6.0.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (6.0.2.2)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
@@ -30,11 +30,11 @@ GEM
     kindlerb (1.2.0)
       mustache
       nokogiri
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     mustache (1.1.0)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -52,7 +52,7 @@ GEM
     sdoc (1.0.0)
       rdoc (>= 5.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     w3c_validators (1.3.5)
       json (>= 1.8)
@@ -63,16 +63,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (~> 6.0.2, >= 6.0.2.2)
-  activesupport (~> 6.0.2, >= 6.0.2.2)
+  actionpack (~> 6.0.3)
+  activesupport (~> 6.0.3)
   kindlerb (~> 1.2.0)
   rake (>= 11.1)
   redcarpet (~> 3.2.3)
   sdoc (~> 1.0)
   w3c_validators
-
-RUBY VERSION
-   ruby 2.7.0p0
 
 BUNDLED WITH
    2.1.2

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :guides do
     desc "Generate HTML guides"
     task :html do
       ENV["WARNINGS"] = "1" # authors can't disable this
-      ENV["RAILS_VERSION"] = "v6.0.2.2"
+      ENV["RAILS_VERSION"] = "v6.0.3"
       ENV["GUIDES_LANGUAGE"] = "pt-BR"
       system 'cp -r ./pt-BR rails/guides/source'
       ruby "-Eutf-8:utf-8", "rails/guides/rails_guides.rb"

--- a/pt-BR/3_0_release_notes.md
+++ b/pt-BR/3_0_release_notes.md
@@ -74,7 +74,7 @@ $ ruby script/plugin install git://github.com/rails/rails_upgrade.git
 
 You can see an example of how that works at [Rails Upgrade is now an Official Plugin](http://omgbloglol.com/post/364624593/rails-upgrade-is-now-an-official-plugin)
 
-Aside from Rails Upgrade tool, if you need more help, there are people on IRC and [rubyonrails-talk](https://groups.google.com/group/rubyonrails-talk) that are probably doing the same thing, possibly hitting the same issues. Be sure to blog your own experiences when upgrading so others can benefit from your knowledge!
+Aside from Rails Upgrade tool, if you need more help, there are people on IRC and [rubyonrails-talk](https://discuss.rubyonrails.org/c/rubyonrails-talk) that are probably doing the same thing, possibly hitting the same issues. Be sure to blog your own experiences when upgrading so others can benefit from your knowledge!
 
 Creating a Rails 3.0 application
 --------------------------------

--- a/pt-BR/action_controller_overview.md
+++ b/pt-BR/action_controller_overview.md
@@ -704,7 +704,13 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Note nesse caso que o filtro utiliza `send`  porque o método `logged_in?` é privado e o filtro não é executado no escopo do *controller*. Essa não é a forma recomendada para implementar esse filtro em particular, mas ele pode ser útil em casos mais simples.
+Note nesse caso que o filtro utiliza `send` porque o método `logged_in?` é privado e o filtro não é executado no escopo do *controller*. Essa não é a forma recomendada para implementar esse filtro em particular, mas ele pode ser útil em casos mais simples.
+
+Especificamente para `around_action`, o bloco também acessa a `action`:
+
+```ruby
+around_action { |_controller, action| time(&action) }
+```
 
 A segunda forma é utilizar uma classe (na verdade, qualquer objeto que responda aos métodos corretos serve) para gerenciar a filtragem. Isto é útil em casos mais complexos que não são possíveis de serem implementados de uma forma de fácil leitura e reutilizados usando as outras duas abordagens. Por exemplo, você pode reescrever o filtro de login novamente utilizando uma classe:
 

--- a/pt-BR/active_record_callbacks.md
+++ b/pt-BR/active_record_callbacks.md
@@ -118,6 +118,8 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 
 WARNING. `after_save` runs both on create and update, but always _after_ the more specific callbacks `after_create` and `after_update`, no matter the order in which the macro calls were executed.
 
+WARNING. Care should be taken in callbacks to avoid updating attributes. For example, avoid running `update(attribute: "value")` and similar code during callbacks. This can alter the state of the model and may result in unexpected side effects during commit. Instead, you should try to assign values in the `before_create` or earlier callbacks.
+
 NOTE: `before_destroy` callbacks should be placed before `dependent: :destroy`
 associations (or use the `prepend: true` option), to ensure they execute before
 the records are deleted by `dependent: :destroy`.

--- a/pt-BR/active_record_multiple_databases.md
+++ b/pt-BR/active_record_multiple_databases.md
@@ -241,18 +241,6 @@ The "role" in the `connected_to` call looks up the connections that are connecte
 connection handler (or role). The `reading` connection handler will hold all the connections
 that were connected via `connects_to` with the role name of `reading`.
 
-There also may be a case where you have a database that you don't always want to connect to
-on application boot but may need for a slow query or analytics. After defining that database
-in the `database.yml` you can connect by passing a database argument to `connected_to`
-
-```ruby
-ActiveRecord::Base.connected_to(database: { reading_slow: :animals_slow_replica }) do
-  # do something while connected to the slow replica
-end
-```
-
-The `database` argument for `connected_to` will take a symbol or a config hash.
-
 Note that `connected_to` with a role will look up an existing connection and switch
 using the connection specification name. This means that if you pass an unknown role
 like `connected_to(role: :nonexistent)` you will get an error that says

--- a/pt-BR/active_storage_overview.md
+++ b/pt-BR/active_storage_overview.md
@@ -418,19 +418,25 @@ message.video.open do |file|
 end
 ```
 
+Analyzing Files
+---------------
+
+Active Storage [analyzes](https://api.rubyonrails.org/classes/ActiveStorage/Blob/Analyzable.html#method-i-analyze) files once they've been uploaded by queuing a job in Active Job. Analyzed files will store additional information in the metadata hash, including `analyzed: true`. You can check whether a blob has been analyzed by calling `analyzed?` on it.
+
+Image analysis provides `width` and `height` attributes. Video analysis provides these, as well as `duration`, `angle`, and `display_aspect_ratio`.
+
+Analysis requires the `mini_magick` gem. Video analysis also requires the [FFmpeg](https://www.ffmpeg.org/) library, which you must include separately.
+
 Transforming Images
 -------------------
-
-To create a variation of the image, call `variant` on the `Blob`. You can pass
-any transformation to the method supported by the processor. The default
-processor is [MiniMagick](https://github.com/minimagick/minimagick), but you
-can also use [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
 To enable variants, add the `image_processing` gem to your `Gemfile`:
 
 ```ruby
-gem 'image_processing', '~> 1.2'
+gem 'image_processing'
 ```
+
+To create a variation of an image, call `variant` on the `Blob`. You can pass any transformation to the method supported by the processor. The default processor for Active Storage is MiniMagick, but you can also use [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
 When the browser hits the variant URL, Active Storage will lazily transform the
 original blob into the specified format and redirect to its new service
@@ -601,9 +607,10 @@ addEventListener("direct-upload:initialize", event => {
   target.insertAdjacentHTML("beforebegin", `
     <div id="direct-upload-${id}" class="direct-upload direct-upload--pending">
       <div id="direct-upload-progress-${id}" class="direct-upload__progress" style="width: 0%"></div>
-      <span class="direct-upload__filename">${file.name}</span>
+      <span class="direct-upload__filename"></span>
     </div>
   `)
+  target.previousElementSibling.querySelector(`.direct-upload__filename`).textContent = file.name
 })
 
 addEventListener("direct-upload:start", event => {

--- a/pt-BR/asset_pipeline.md
+++ b/pt-BR/asset_pipeline.md
@@ -571,7 +571,7 @@ config.assets.unknown_asset_fallback = false
 ```
 
 If "asset fallback" is enabled then when an asset cannot be found the path will be
-output instead and no error raised. The asset fallback behavior is enabled by default.
+output instead and no error raised. The asset fallback behavior is disabled by default.
 
 ### Turning Digests Off
 

--- a/pt-BR/autoloading_and_reloading_constants.md
+++ b/pt-BR/autoloading_and_reloading_constants.md
@@ -231,11 +231,11 @@ module StiPreload
       def preload_sti
         types_in_db = \
           base_class.
+            unscoped.
             select(inheritance_column).
             distinct.
             pluck(inheritance_column).
-            compact.
-            each(&:constantize)
+            compact
 
         types_in_db.each do |type|
           logger.debug("Preloading STI type #{type}")

--- a/pt-BR/autoloading_and_reloading_constants_classic_mode.md
+++ b/pt-BR/autoloading_and_reloading_constants_classic_mode.md
@@ -895,6 +895,46 @@ module Admin
 end
 ```
 
+### Defining vs Reopening Namespaces
+
+Let's consider:
+
+```ruby
+# app/models/blog.rb
+module Blog
+  def self.table_name_prefix
+    "blog_"
+  end
+end
+
+# app/models/blog/post.rb
+module Blog
+  class Post < ApplicationRecord
+  end
+end
+```
+
+The table name for `Blog::Post` should be `blog_posts` due to the existence of
+the method `Blog.table_name_prefix`. However, if `app/models/blog/post.rb` is
+executed before `app/models/blog.rb` is, Active Record is not aware of the
+existence of such method, and assumes the table is `posts`.
+
+To resolve a situation like this, it helps thinking clearly about which file
+_defines_ the `Blog` module (`app/models/blog.rb`), and which one _reopens_ it
+(`app/models/blog/post.rb`). Then, you ensure that the definition is executed
+first using `require_dependency`:
+
+```ruby
+# app/models/blog/post.rb
+
+require_dependency "blog"
+
+module Blog
+  class Post < ApplicationRecord
+  end
+end
+```
+
 ### Autoloading and STI
 
 Single Table Inheritance (STI) is a feature of Active Record that enables

--- a/pt-BR/configuring.md
+++ b/pt-BR/configuring.md
@@ -330,6 +330,44 @@ The full set of methods that can be used in this block are as follows:
 
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
+* `ActionDispatch::HostAuthorization` prevents against DNS rebinding and other `Host` header attacks.
+   It is included in the development environment by default with the following configuration:
+
+   ```ruby
+   Rails.application.config.hosts = [
+     IPAddr.new("0.0.0.0/0"), # All IPv4 addresses.
+     IPAddr.new("::/0"),      # All IPv6 addresses.
+     "localhost"              # The localhost reserved domain.
+   ]
+   ```
+
+   In other environments `Rails.application.config.hosts` is empty and no
+   `Host` header checks will be done. If you want to guard against header
+   attacks on production, you have to manually permit the allowed hosts
+   with:
+
+   ```ruby
+   Rails.application.config.hosts << "product.com"
+   ```
+
+   The host of a request is checked against the `hosts` entries with the case
+   operator (`#===`), which lets `hosts` support entries of type `Regexp`,
+   `Proc` and `IPAddr` to name a few. Here is an example with a regexp.
+
+   ```ruby
+   # Allow requests from subdomains like `www.product.com` and
+   # `beta1.product.com`.
+   Rails.application.config.hosts << /.*\.product\.com/
+   ```
+
+   A special case is supported that allows you to permit all sub-domains:
+
+   ```ruby
+   # Allow requests from subdomains like `www.product.com` and
+   # `beta1.product.com`.
+   Rails.application.config.hosts << ".product.com"
+   ```
+
 * `ActionDispatch::SSL` forces every request to be served using HTTPS. Enabled if `config.force_ssl` is set to `true`. Options passed to this can be configured by setting `config.ssl_options`.
 * `ActionDispatch::Static` is used to serve static assets. Disabled if `config.public_file_server.enabled` is `false`. Set `config.public_file_server.index_name` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.public_file_server.index_name` to `"main"`.
 * `ActionDispatch::Executor` allows thread safe code reloading. Disabled if `config.allow_concurrency` is `false`, which causes `Rack::Lock` to be loaded. `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time.
@@ -1653,7 +1691,7 @@ evented file system monitor to detect changes when `config.cache_classes` is
 
 ```ruby
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.2'
 end
 ```
 

--- a/pt-BR/contributing_to_ruby_on_rails.md
+++ b/pt-BR/contributing_to_ruby_on_rails.md
@@ -73,7 +73,7 @@ submissions! They just won't get backported to maintenance branches.
 
 If you'd like feedback on an idea for a feature before doing the work to make
 a patch, please send an email to the [rails-core mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core). You
+list](https://discuss.rubyonrails.org/c/rubyonrails-core). You
 might get no response, which means that everyone is indifferent. You might find
 someone who's also interested in building that feature. You might get a "This
 won't be accepted." But it's the proper place to discuss new ideas. GitHub
@@ -587,7 +587,7 @@ is the open source life.
 
 If it's been over a week, and you haven't heard anything, you might want to try
 and nudge things along. You can use the [rubyonrails-core mailing
-list](https://groups.google.com/forum/#!forum/rubyonrails-core) for this. You can also
+list](https://discuss.rubyonrails.org/c/rubyonrails-core) for this. You can also
 leave another comment on the pull request.
 
 While you're waiting for feedback on your pull request, open up a few other

--- a/pt-BR/debugging_rails_applications.md
+++ b/pt-BR/debugging_rails_applications.md
@@ -252,12 +252,13 @@ logger.tagged("BCX") { logger.tagged("Jason") { logger.info "Stuff" } } # Logs "
 ```
 
 ### Impact of Logs on Performance
+
 Logging will always have a small impact on the performance of your Rails app,
-        particularly when logging to disk. Additionally, there are a few subtleties:
+particularly when logging to disk. Additionally, there are a few subtleties:
 
 Using the `:debug` level will have a greater performance penalty than `:fatal`,
-      as a far greater number of strings are being evaluated and written to the
-      log output (e.g. disk).
+as a far greater number of strings are being evaluated and written to the
+log output (e.g. disk).
 
 Another potential pitfall is too many calls to `Logger` in your code:
 
@@ -269,6 +270,7 @@ In the above example, there will be a performance impact even if the allowed
 output level doesn't include debug. The reason is that Ruby has to evaluate
 these strings, which includes instantiating the somewhat heavy `String` object
 and interpolating the variables.
+
 Therefore, it's recommended to pass blocks to the logger methods, as these are
 only evaluated if the output level is the same as — or included in — the allowed level
 (i.e. lazy loading). The same code rewritten would be:
@@ -280,6 +282,9 @@ logger.debug {"Person attributes hash: #{@person.attributes.inspect}"}
 The contents of the block, and therefore the string interpolation, are only
 evaluated if debug is enabled. This performance savings are only really
 noticeable with large amounts of logging, but it's a good practice to employ.
+
+INFO: This section was written by [Jon Cairns at a StackOverflow answer](https://stackoverflow.com/questions/16546730/logging-in-rails-is-there-any-performance-hit/16546935#16546935)
+and it is licensed under [cc by-sa 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
 
 *Debug* com a gem `byebug`
 ---------------------------------

--- a/pt-BR/development_dependencies_install.md
+++ b/pt-BR/development_dependencies_install.md
@@ -133,12 +133,9 @@ $ sudo dnf install yarn
 To install all run:
 
 ```bash
-$ sudo pacman -S sqlite
-    mariadb libmariadbclient mariadb-clients
-    postgresql postgresql-libs
-    redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler
-    yarn
-$ sudo systemctl start redis
+$ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2
+$ sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+$ sudo systemctl start redis mariadb memcached
 ```
 
 NOTE: If you are running Arch Linux, MySQL isn't supported anymore so you will need to

--- a/pt-BR/getting_started.md
+++ b/pt-BR/getting_started.md
@@ -65,7 +65,14 @@ Se você está utilizando Windows, seu *prompt* será parecido com algo como `c:
 ### Instalando o Rails
 
 Antes de você instalar o Rails, você deve validar para ter certeza que seu sistema
-tem os pré requisitos necessários instalados. Esses incluem Ruby e SQLite3.
+tem os pré requisitos necessários instalados. Esses incluem:
+
+* Ruby 
+* SQLite3
+* Node.js
+* Yarn
+
+#### Instalando o Ruby
 
 Abra o *prompt* de linha de comando. No *macOS* abra o *Terminal.app*, no *Windows*
 escolha *executar* no menu inicial e digite 'cmd.exe'. Qualquer comando que antecede
@@ -87,6 +94,8 @@ de outros Sistemas Operacionais, dê uma olhada em [ruby-lang.org](https://www.r
 Se você está utilizando o Windowns, você deve também instalar o
 [Ruby Installer Development Kit](https://rubyinstaller.org/downloads/).
 
+#### Instalando o SQLite3
+
 Você também precisará instalar o banco de dados SQLite3.
 Muitos sistemas operacionais populares semelhantes ao UNIX são fornecidos com uma versão compatível do SQLite3.
 No Windows, se você instalou o Rails pelo instalador do Rails, você
@@ -98,6 +107,33 @@ $ sqlite3 --version
 ```
 
 O programa deverá reportar sua versão.
+
+#### Instalando o Node.js e Yarn
+
+Por fim, você precisará do Node.js e o Yarn instalados para gerenciar o JavaScript da sua aplicação.
+
+Encontre as instruções de instalação no [site do Node.js](https://nodejs.org/en/download/) e
+verifique se está instalado corretamente com o seguinte comando:
+
+```bash 
+$ node --version
+```
+
+A versão do Node.js deve ser impressa. Certifique-se de que é maior
+que 8.16.0.
+
+Para instalar o Yarn, siga as instruções de instalação
+instruções no [site do Yarn](https://classic.yarnpkg.com/en/docs/install).
+
+A execução deste comando deve imprimir a versão do Yarn:
+
+```bash
+$ yarn -v
+```
+
+Se aparecer algo como "1.22.0", o Yarn foi instalado corretamente.
+
+#### Instalando o Rails
 
 Para instalar o Rails, use o comando `gem install` fornecido pelo RubyGems:
 
@@ -1954,7 +1990,7 @@ consultar estes recursos:
 
 * O [Guia Rails](index.html)
 * O [Ruby on Rails Guides](https://guides.rubyonrails.org)
-* A [lista de discussão do Ruby on Rails](https://groups.google.com/group/rubyonrails-talk)
+* A [lista de discussão do Ruby on Rails](https://discuss.rubyonrails.org/c/rubyonrails-talk)
 * O canal [#rubyonrails](irc://irc.freenode.net/#rubyonrails) no irc.freenode.net
 
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -1166,7 +1166,7 @@ In other contexts you might want to change this behavior, though. E.g. the defau
 module I18n
   class JustRaiseExceptionHandler < ExceptionHandler
     def call(exception, locale, key, options)
-      if exception.is_a?(MissingTranslationData)
+      if exception.is_a?(MissingTranslation)
         raise exception.to_exception
       else
         super
@@ -1183,7 +1183,7 @@ This would re-raise only the `MissingTranslationData` exception, passing all oth
 However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use additional check for translation key:
 
 ```ruby
-if exception.is_a?(MissingTranslationData) && key.to_s != 'i18n.plural.rule'
+if exception.is_a?(MissingTranslation) && key.to_s != 'i18n.plural.rule'
   raise exception.to_exception
 else
   super

--- a/pt-BR/layout.html.erb
+++ b/pt-BR/layout.html.erb
@@ -117,7 +117,7 @@
         </p>
         <p>
           E por último, mas não menos importante, qualquer tipo de discussão sobre a documentação do Ruby on Rails
-          é muito bem vinda na <%= link_to 'lista de discussão rubyonrails-docs', 'https://groups.google.com/forum/#!forum/rubyonrails-docs' %> e nas
+          é muito bem vinda na <%= link_to 'lista de discussão rubyonrails-docs', 'https://discuss.rubyonrails.org/c/rubyonrails-docs' %> e nas
           <%= link_to 'issues do Guia em português', 'https://github.com/campuscode/rails-guides-pt-BR/issues' %>.
         </p>
       </div>

--- a/pt-BR/maintenance_policy.md
+++ b/pt-BR/maintenance_policy.md
@@ -55,7 +55,7 @@ and new versions in case of a security issue.
 
 These releases are created by taking the last released version, applying the
 security patches, and releasing. Those patches are then applied to the end of
-the x-y-stable branch. For example, a theoretical 1.2.3 security release would
+the x-y-stable branch. For example, a theoretical 1.2.2.1 security release would
 be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.

--- a/pt-BR/testing.md
+++ b/pt-BR/testing.md
@@ -1400,10 +1400,11 @@ end
 
 #### Using Separate Files
 
-If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files. One good place to store them is `lib/test`.
+If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files.
+One good place to store them is `test/lib` or `test/test_helpers`.
 
 ```ruby
-# lib/test/multiple_assertions.rb
+# test/test_helpers/multiple_assertions.rb
 module MultipleAssertions
   def assert_multiple_of_forty_two(number)
     assert (number % 42 == 0), 'expected #{number} to be a multiple of 42'
@@ -1415,7 +1416,7 @@ These helpers can then be explicitly required as needed and included as needed
 
 ```ruby
 require 'test_helper'
-require 'test/multiple_assertions'
+require 'test_helpers/multiple_assertions'
 
 class NumberTest < ActiveSupport::TestCase
   include MultipleAssertions
@@ -1430,7 +1431,7 @@ or they can continue to be included directly into the relevant parent classes
 
 ```ruby
 # test/test_helper.rb
-require 'test/sign_in_helper'
+require 'test_helpers/sign_in_helper'
 
 class ActionDispatch::IntegrationTest
   include SignInHelper
@@ -1443,7 +1444,7 @@ You may find it convenient to eagerly require helpers in `test_helper.rb` so you
 
 ```ruby
 # test/test_helper.rb
-Dir[Rails.root.join('lib', 'test', '**', '*.rb')].each { |file| require file }
+Dir[Rails.root.join('test', 'test_helpers', '**', '*.rb')].each { |file| require file }
 ```
 
 This has the downside of increasing the boot-up time, as opposed to manually requiring only the necessary files in your individual tests.

--- a/source/3_0_release_notes.md
+++ b/source/3_0_release_notes.md
@@ -73,7 +73,7 @@ $ ruby script/plugin install git://github.com/rails/rails_upgrade.git
 
 You can see an example of how that works at [Rails Upgrade is now an Official Plugin](http://omgbloglol.com/post/364624593/rails-upgrade-is-now-an-official-plugin)
 
-Aside from Rails Upgrade tool, if you need more help, there are people on IRC and [rubyonrails-talk](https://groups.google.com/group/rubyonrails-talk) that are probably doing the same thing, possibly hitting the same issues. Be sure to blog your own experiences when upgrading so others can benefit from your knowledge!
+Aside from Rails Upgrade tool, if you need more help, there are people on IRC and [rubyonrails-talk](https://discuss.rubyonrails.org/c/rubyonrails-talk) that are probably doing the same thing, possibly hitting the same issues. Be sure to blog your own experiences when upgrading so others can benefit from your knowledge!
 
 Creating a Rails 3.0 application
 --------------------------------

--- a/source/action_controller_overview.md
+++ b/source/action_controller_overview.md
@@ -753,6 +753,12 @@ end
 
 Note that the filter in this case uses `send` because the `logged_in?` method is private and the filter does not run in the scope of the controller. This is not the recommended way to implement this particular filter, but in more simple cases it might be useful.
 
+Specifically for `around_action`, the block also yields in the `action`:
+
+```ruby
+around_action { |_controller, action| time(&action) }
+```
+
 The second way is to use a class (actually, any object that responds to the right methods will do) to handle the filtering. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login filter again to use a class:
 
 ```ruby

--- a/source/active_record_callbacks.md
+++ b/source/active_record_callbacks.md
@@ -117,6 +117,8 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 
 WARNING. `after_save` runs both on create and update, but always _after_ the more specific callbacks `after_create` and `after_update`, no matter the order in which the macro calls were executed.
 
+WARNING. Care should be taken in callbacks to avoid updating attributes. For example, avoid running `update(attribute: "value")` and similar code during callbacks. This can alter the state of the model and may result in unexpected side effects during commit. Instead, you should try to assign values in the `before_create` or earlier callbacks.
+
 NOTE: `before_destroy` callbacks should be placed before `dependent: :destroy`
 associations (or use the `prepend: true` option), to ensure they execute before
 the records are deleted by `dependent: :destroy`.

--- a/source/active_record_multiple_databases.md
+++ b/source/active_record_multiple_databases.md
@@ -240,18 +240,6 @@ The "role" in the `connected_to` call looks up the connections that are connecte
 connection handler (or role). The `reading` connection handler will hold all the connections
 that were connected via `connects_to` with the role name of `reading`.
 
-There also may be a case where you have a database that you don't always want to connect to
-on application boot but may need for a slow query or analytics. After defining that database
-in the `database.yml` you can connect by passing a database argument to `connected_to`
-
-```ruby
-ActiveRecord::Base.connected_to(database: { reading_slow: :animals_slow_replica }) do
-  # do something while connected to the slow replica
-end
-```
-
-The `database` argument for `connected_to` will take a symbol or a config hash.
-
 Note that `connected_to` with a role will look up an existing connection and switch
 using the connection specification name. This means that if you pass an unknown role
 like `connected_to(role: :nonexistent)` you will get an error that says

--- a/source/active_storage_overview.md
+++ b/source/active_storage_overview.md
@@ -417,19 +417,25 @@ message.video.open do |file|
 end
 ```
 
+Analyzing Files
+---------------
+
+Active Storage [analyzes](https://api.rubyonrails.org/classes/ActiveStorage/Blob/Analyzable.html#method-i-analyze) files once they've been uploaded by queuing a job in Active Job. Analyzed files will store additional information in the metadata hash, including `analyzed: true`. You can check whether a blob has been analyzed by calling `analyzed?` on it.
+
+Image analysis provides `width` and `height` attributes. Video analysis provides these, as well as `duration`, `angle`, and `display_aspect_ratio`.
+
+Analysis requires the `mini_magick` gem. Video analysis also requires the [FFmpeg](https://www.ffmpeg.org/) library, which you must include separately.
+
 Transforming Images
 -------------------
-
-To create a variation of the image, call `variant` on the `Blob`. You can pass
-any transformation to the method supported by the processor. The default
-processor is [MiniMagick](https://github.com/minimagick/minimagick), but you
-can also use [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
 To enable variants, add the `image_processing` gem to your `Gemfile`:
 
 ```ruby
-gem 'image_processing', '~> 1.2'
+gem 'image_processing'
 ```
+
+To create a variation of an image, call `variant` on the `Blob`. You can pass any transformation to the method supported by the processor. The default processor for Active Storage is MiniMagick, but you can also use [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
 When the browser hits the variant URL, Active Storage will lazily transform the
 original blob into the specified format and redirect to its new service
@@ -600,9 +606,10 @@ addEventListener("direct-upload:initialize", event => {
   target.insertAdjacentHTML("beforebegin", `
     <div id="direct-upload-${id}" class="direct-upload direct-upload--pending">
       <div id="direct-upload-progress-${id}" class="direct-upload__progress" style="width: 0%"></div>
-      <span class="direct-upload__filename">${file.name}</span>
+      <span class="direct-upload__filename"></span>
     </div>
   `)
+  target.previousElementSibling.querySelector(`.direct-upload__filename`).textContent = file.name
 })
 
 addEventListener("direct-upload:start", event => {

--- a/source/asset_pipeline.md
+++ b/source/asset_pipeline.md
@@ -570,7 +570,7 @@ config.assets.unknown_asset_fallback = false
 ```
 
 If "asset fallback" is enabled then when an asset cannot be found the path will be
-output instead and no error raised. The asset fallback behavior is enabled by default.
+output instead and no error raised. The asset fallback behavior is disabled by default.
 
 ### Turning Digests Off
 

--- a/source/autoloading_and_reloading_constants.md
+++ b/source/autoloading_and_reloading_constants.md
@@ -230,11 +230,11 @@ module StiPreload
       def preload_sti
         types_in_db = \
           base_class.
+            unscoped.
             select(inheritance_column).
             distinct.
             pluck(inheritance_column).
-            compact.
-            each(&:constantize)
+            compact
 
         types_in_db.each do |type|
           logger.debug("Preloading STI type #{type}")

--- a/source/configuring.md
+++ b/source/configuring.md
@@ -230,6 +230,44 @@ The full set of methods that can be used in this block are as follows:
 
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
+* `ActionDispatch::HostAuthorization` prevents against DNS rebinding and other `Host` header attacks.
+   It is included in the development environment by default with the following configuration:
+
+   ```ruby
+   Rails.application.config.hosts = [
+     IPAddr.new("0.0.0.0/0"), # All IPv4 addresses.
+     IPAddr.new("::/0"),      # All IPv6 addresses.
+     "localhost"              # The localhost reserved domain.
+   ]
+   ```
+
+   In other environments `Rails.application.config.hosts` is empty and no
+   `Host` header checks will be done. If you want to guard against header
+   attacks on production, you have to manually permit the allowed hosts
+   with:
+
+   ```ruby
+   Rails.application.config.hosts << "product.com"
+   ```
+
+   The host of a request is checked against the `hosts` entries with the case
+   operator (`#===`), which lets `hosts` support entries of type `Regexp`,
+   `Proc` and `IPAddr` to name a few. Here is an example with a regexp.
+
+   ```ruby
+   # Allow requests from subdomains like `www.product.com` and
+   # `beta1.product.com`.
+   Rails.application.config.hosts << /.*\.product\.com/
+   ```
+
+   A special case is supported that allows you to permit all sub-domains:
+
+   ```ruby
+   # Allow requests from subdomains like `www.product.com` and
+   # `beta1.product.com`.
+   Rails.application.config.hosts << ".product.com"
+   ```
+
 * `ActionDispatch::SSL` forces every request to be served using HTTPS. Enabled if `config.force_ssl` is set to `true`. Options passed to this can be configured by setting `config.ssl_options`.
 * `ActionDispatch::Static` is used to serve static assets. Disabled if `config.public_file_server.enabled` is `false`. Set `config.public_file_server.index_name` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.public_file_server.index_name` to `"main"`.
 * `ActionDispatch::Executor` allows thread safe code reloading. Disabled if `config.allow_concurrency` is `false`, which causes `Rack::Lock` to be loaded. `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time.
@@ -1553,7 +1591,7 @@ evented file system monitor to detect changes when `config.cache_classes` is
 
 ```ruby
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.2'
 end
 ```
 

--- a/source/contributing_to_ruby_on_rails.md
+++ b/source/contributing_to_ruby_on_rails.md
@@ -73,7 +73,7 @@ submissions! They just won't get backported to maintenance branches.
 
 If you'd like feedback on an idea for a feature before doing the work to make
 a patch, please send an email to the [rails-core mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core). You
+list](https://discuss.rubyonrails.org/c/rubyonrails-core). You
 might get no response, which means that everyone is indifferent. You might find
 someone who's also interested in building that feature. You might get a "This
 won't be accepted." But it's the proper place to discuss new ideas. GitHub
@@ -587,7 +587,7 @@ is the open source life.
 
 If it's been over a week, and you haven't heard anything, you might want to try
 and nudge things along. You can use the [rubyonrails-core mailing
-list](https://groups.google.com/forum/#!forum/rubyonrails-core) for this. You can also
+list](https://discuss.rubyonrails.org/c/rubyonrails-core) for this. You can also
 leave another comment on the pull request.
 
 While you're waiting for feedback on your pull request, open up a few other

--- a/source/debugging_rails_applications.md
+++ b/source/debugging_rails_applications.md
@@ -252,12 +252,13 @@ logger.tagged("BCX") { logger.tagged("Jason") { logger.info "Stuff" } } # Logs "
 ```
 
 ### Impact of Logs on Performance
+
 Logging will always have a small impact on the performance of your Rails app,
-        particularly when logging to disk. Additionally, there are a few subtleties:
+particularly when logging to disk. Additionally, there are a few subtleties:
 
 Using the `:debug` level will have a greater performance penalty than `:fatal`,
-      as a far greater number of strings are being evaluated and written to the
-      log output (e.g. disk).
+as a far greater number of strings are being evaluated and written to the
+log output (e.g. disk).
 
 Another potential pitfall is too many calls to `Logger` in your code:
 
@@ -269,6 +270,7 @@ In the above example, there will be a performance impact even if the allowed
 output level doesn't include debug. The reason is that Ruby has to evaluate
 these strings, which includes instantiating the somewhat heavy `String` object
 and interpolating the variables.
+
 Therefore, it's recommended to pass blocks to the logger methods, as these are
 only evaluated if the output level is the same as — or included in — the allowed level
 (i.e. lazy loading). The same code rewritten would be:
@@ -280,6 +282,9 @@ logger.debug {"Person attributes hash: #{@person.attributes.inspect}"}
 The contents of the block, and therefore the string interpolation, are only
 evaluated if debug is enabled. This performance savings are only really
 noticeable with large amounts of logging, but it's a good practice to employ.
+
+INFO: This section was written by [Jon Cairns at a StackOverflow answer](https://stackoverflow.com/questions/16546730/logging-in-rails-is-there-any-performance-hit/16546935#16546935)
+and it is licensed under [cc by-sa 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
 
 Debugging with the `byebug` gem
 ---------------------------------

--- a/source/development_dependencies_install.md
+++ b/source/development_dependencies_install.md
@@ -132,12 +132,9 @@ $ sudo dnf install yarn
 To install all run:
 
 ```bash
-$ sudo pacman -S sqlite
-    mariadb libmariadbclient mariadb-clients
-    postgresql postgresql-libs
-    redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler
-    yarn
-$ sudo systemctl start redis
+$ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2
+$ sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+$ sudo systemctl start redis mariadb memcached
 ```
 
 NOTE: If you are running Arch Linux, MySQL isn't supported anymore so you will need to

--- a/source/getting_started.md
+++ b/source/getting_started.md
@@ -78,7 +78,14 @@ your prompt will look something like `c:\source_code>`
 ### Installing Rails
 
 Before you install Rails, you should check to make sure that your system has the
-proper prerequisites installed. These include Ruby and SQLite3.
+proper prerequisites installed. These include:
+
+* Ruby 
+* SQLite3
+* Node.js
+* Yarn
+
+#### Installing Ruby
 
 Open up a command line prompt. On macOS open Terminal.app, on Windows choose
 "Run" from your Start menu and type 'cmd.exe'. Any commands prefaced with a
@@ -100,6 +107,8 @@ Operating Systems take a look at [ruby-lang.org](https://www.ruby-lang.org/en/do
 If you are working on Windows, you should also install the
 [Ruby Installer Development Kit](https://rubyinstaller.org/downloads/).
 
+#### Installing SQLite3
+
 You will also need an installation of the SQLite3 database.
 Many popular UNIX-like OSes ship with an acceptable version of SQLite3.
 On Windows, if you installed Rails through Rails Installer, you
@@ -112,6 +121,33 @@ $ sqlite3 --version
 ```
 
 The program should report its version.
+
+#### Installing Node.js and Yarn
+
+Finally, you'll need Node.js and Yarn installed to manage your application's JavaScript.
+
+Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and 
+verify it's installed correctly with the following command:
+
+```bash 
+$ node --version
+```
+
+The version of your Node.js runtime should be printed out. Make sure it's greater
+than 8.16.0.
+
+To install Yarn, follow the installation
+instructions at the [Yarn website](https://classic.yarnpkg.com/en/docs/install).
+
+Running this command should print out Yarn version:
+
+```bash
+$ yarn -v
+```
+
+If it says something like "1.22.0", Yarn has been installed correctly.
+
+#### Installing Rails
 
 To install Rails, use the `gem install` command provided by RubyGems:
 
@@ -2058,7 +2094,7 @@ getting up and running with Rails, feel free to consult these support
 resources:
 
 * The [Ruby on Rails Guides](index.html)
-* The [Ruby on Rails mailing list](https://groups.google.com/group/rubyonrails-talk)
+* The [Ruby on Rails mailing list](https://discuss.rubyonrails.org/c/rubyonrails-talk)
 * The [#rubyonrails](irc://irc.freenode.net/#rubyonrails) channel on irc.freenode.net
 
 

--- a/source/i18n.md
+++ b/source/i18n.md
@@ -1166,7 +1166,7 @@ In other contexts you might want to change this behavior, though. E.g. the defau
 module I18n
   class JustRaiseExceptionHandler < ExceptionHandler
     def call(exception, locale, key, options)
-      if exception.is_a?(MissingTranslationData)
+      if exception.is_a?(MissingTranslation)
         raise exception.to_exception
       else
         super
@@ -1183,7 +1183,7 @@ This would re-raise only the `MissingTranslationData` exception, passing all oth
 However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use additional check for translation key:
 
 ```ruby
-if exception.is_a?(MissingTranslationData) && key.to_s != 'i18n.plural.rule'
+if exception.is_a?(MissingTranslation) && key.to_s != 'i18n.plural.rule'
   raise exception.to_exception
 else
   super

--- a/source/layout.html.erb
+++ b/source/layout.html.erb
@@ -116,7 +116,7 @@
           <%= link_to 'open an issue', 'https://github.com/rails/rails/issues' %>.
         </p>
         <p>And last but not least, any kind of discussion regarding Ruby on Rails
-          documentation is very welcome on the <%= link_to 'rubyonrails-docs mailing list', 'https://groups.google.com/forum/#!forum/rubyonrails-docs' %>.
+          documentation is very welcome on the <%= link_to 'rubyonrails-docs mailing list', 'https://discuss.rubyonrails.org/c/rubyonrails-docs' %>.
         </p>
       </div>
     </div>

--- a/source/maintenance_policy.md
+++ b/source/maintenance_policy.md
@@ -54,7 +54,7 @@ and new versions in case of a security issue.
 
 These releases are created by taking the last released version, applying the
 security patches, and releasing. Those patches are then applied to the end of
-the x-y-stable branch. For example, a theoretical 1.2.3 security release would
+the x-y-stable branch. For example, a theoretical 1.2.2.1 security release would
 be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.

--- a/source/testing.md
+++ b/source/testing.md
@@ -1399,10 +1399,11 @@ end
 
 #### Using Separate Files
 
-If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files. One good place to store them is `lib/test`.
+If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files.
+One good place to store them is `test/lib` or `test/test_helpers`.
 
 ```ruby
-# lib/test/multiple_assertions.rb
+# test/test_helpers/multiple_assertions.rb
 module MultipleAssertions
   def assert_multiple_of_forty_two(number)
     assert (number % 42 == 0), 'expected #{number} to be a multiple of 42'
@@ -1414,7 +1415,7 @@ These helpers can then be explicitly required as needed and included as needed
 
 ```ruby
 require 'test_helper'
-require 'test/multiple_assertions'
+require 'test_helpers/multiple_assertions'
 
 class NumberTest < ActiveSupport::TestCase
   include MultipleAssertions
@@ -1429,7 +1430,7 @@ or they can continue to be included directly into the relevant parent classes
 
 ```ruby
 # test/test_helper.rb
-require 'test/sign_in_helper'
+require 'test_helpers/sign_in_helper'
 
 class ActionDispatch::IntegrationTest
   include SignInHelper
@@ -1442,7 +1443,7 @@ You may find it convenient to eagerly require helpers in `test_helper.rb` so you
 
 ```ruby
 # test/test_helper.rb
-Dir[Rails.root.join('lib', 'test', '**', '*.rb')].each { |file| require file }
+Dir[Rails.root.join('test', 'test_helpers', '**', '*.rb')].each { |file| require file }
 ```
 
 This has the downside of increasing the boot-up time, as opposed to manually requiring only the necessary files in your individual tests.


### PR DESCRIPTION
## Motivação

Fazer upgrade do Guia para a versão 6.0.3 do Rails.

## Comentários

- Atualizei o Gemfile com as novas versões
- O Getting Started foi particularmente desafiador de atualizar porque envolvia traduzir um novo pedaço que não existia anteriormente
