### PR TITLE
Retirando WIP da página de Rotas

### DIFF
--- a/pt-BR/documents.yaml
+++ b/pt-BR/documents.yaml
@@ -70,7 +70,6 @@
       name: Rails Routing from the Outside In
       url: routing.html
       description: Este guia aborda os recursos voltados ao usuário das rotas do Rails. Se você quiser entender como usar o roteamento em suas aplicações Rails, comece por aqui.
-      work_in_progress: true
 -
   name: Outros componentes
   documents:


### PR DESCRIPTION
## Motivação

Fechamos todas as issues dessa página e o [milestone](https://github.com/campuscode/rails-guides-pt-BR/milestone/11) fechado podemos remover o WIP dessa página 👏 