### PR TITLE
Typo na página de Form Helper

### DIFF
--- a/pt-BR/form_helpers.md
+++ b/pt-BR/form_helpers.md
@@ -349,6 +349,7 @@ Criando Caixas de Seleção (*Select Boxes*) com Facilidade
 As caixas de seleção em HTML requerem uma quantidade significativa de marcação (um elemento `OPTION` para cada opção de escolha), portanto, faz mais sentido que sejam geradas dinamicamente.
 
 Esta é a aparência da marcação:
+
 ```html
 <select name="city_id" id="city_id">
   <option value="1">Lisbon</option>


### PR DESCRIPTION
Aqui faltou um quebra de linha que estava dando bug na geração do html da página 😢 

![image](https://user-images.githubusercontent.com/9326123/97456262-74d52500-1917-11eb-9076-9219dc284a80.png)
