### PR TITLE
Deploy para o branch site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy:
+    #if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN   }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: |
+          echo "==== Submodule initiation ===="
+          git submodule update --init 
+          echo "==== Installing gems ===="
+          bundle install
+      - name: Generate guides files
+        run: rake assets:precompile
+      - name: Setup
+        run: |
+          echo "==== Configuring Git ===="
+          rm -rf .git
+          git init
+          echo "==== Configuring Git user ===="
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: Commit site changes
+        run: |
+          echo "==== Creating branch and commit ===="
+          git remote add origin https://x-access-token:$GH_PERSONAL_ACCESS_TOKEN@github.com/${{ github.repository }}.git
+          git add site/
+          git commit -m "Build from commit ${GITHUB_SHA}"
+          echo "==== Push to site branch ===="
+          git push origin HEAD:site --force
+      - name: Comment on merged pull request
+        run: |
+          curl --silent --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments \
+          --header 'Accept: application/vnd.github.squirrel-girl-preview' \
+          --header 'Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}' \
+          --header 'Content-Type: application/json' \
+          --data '{
+            "body": "Já está disponível no Guia Rails :tada: :rocket:"
+          }' > /dev/null
+      - name: Add label on merged pull request
+        run: |
+          curl --silent --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
+          --header 'Accept: application/vnd.github.squirrel-girl-preview' \
+          --header 'Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}' \
+          --header 'Content-Type: application/json' \
+          --data '{
+            "labels": [":rocket:"]
+          }' > /dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,39 +6,40 @@ on:
 
 jobs:
   deploy:
-    #if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN   }}
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: Install dependencies
         run: |
-          echo "==== Submodule initiation ===="
           git submodule update --init 
-          echo "==== Installing gems ===="
-          bundle install
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
       - name: Generate guides files
         run: rake assets:precompile
-      - name: Setup
+      - name: Git setup
         run: |
-          echo "==== Configuring Git ===="
           rm -rf .git
           git init
-          echo "==== Configuring Git user ===="
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
       - name: Commit site changes
         run: |
-          echo "==== Creating branch and commit ===="
           git remote add origin https://x-access-token:$GH_PERSONAL_ACCESS_TOKEN@github.com/${{ github.repository }}.git
           git add site/
           git commit -m "Build from commit ${GITHUB_SHA}"
-          echo "==== Push to site branch ===="
           git push origin HEAD:site --force
       - name: Comment on merged pull request
         run: |

--- a/lib/search_index.rb
+++ b/lib/search_index.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'open-uri'
+require 'bundler/setup'
 require 'execjs'
 require 'nokogiri'
 


### PR DESCRIPTION
## Motivação

O Guia Rails hoje é hospedado no Heroku e ele tem uma limitação de não aceitar deploy automático se o repositório tiver submodules essa mudança remove essa limitação e torna mais fácil a migração para outros serviços

## Solução proposta

Usar o GitHub Actions para fazer um commit com tudo pronto no branch `site` e esse branch seria levado para produção. 

## Comentários

O GitHub Actions também faz um comentário avisando que o commit já está disponível e usa o meu usuário no momento. O acham de criarmos um Bot User em breve?

Essa também resolve a busca não estar funcionando direito em produção porque os arquivos não são usados corretamente por causa do ephemeral disk do Heroku 🤕 

## Futuro

Uma mudança futura que pode ser realizada é mover todos os arquivos relacionados ao site para esse branch. Isso faria o Guia ficar um pouco mais limpo na branch principal, mas tiraria um pouco da legibilidade do código.