### PR TITLE
Muda workflow de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           git config user.email "<>"
       - name: Commit site changes
         run: |
-          git remote add origin https://x-access-token:$GH_PERSONAL_ACCESS_TOKEN@github.com/${{ github.repository }}.git
+          git remote add origin https://HenriqueMorato:$GH_PERSONAL_ACCESS_TOKEN@github.com/${{ github.repository }}.git
           git add site/
           git commit -m "Build from commit ${GITHUB_SHA}"
           git push origin HEAD:site --force


### PR DESCRIPTION
O deploy tinha um problema de login porque o repo era da organização e não pessoal. Fiz a mudança para logar com o meu usuário no momento.