### PR TITLE
Nome trocado do controller

### DIFF
--- a/pt-BR/getting_started.md
+++ b/pt-BR/getting_started.md
@@ -289,7 +289,7 @@ invoke    scss
 create      app/assets/stylesheets/articles.scss
 ```
 
-Os mais importante desses é o arquivo _controller_, `app/controllers/welcome_controller.rb`. Vamos dar uma olhada nele:
+Os mais importante desses é o arquivo _controller_, `app/controllers/articles_controller.rb`. Vamos dar uma olhada nele:
 
 ```ruby
 class ArticlesController < ApplicationController


### PR DESCRIPTION
Na linha 292, o arquivo está nomeado como: welcome_controller.rb, quando, na verdade, foi criado o controller de Articles, então seu nome deve ser articles_controller.rb

Close: *Adicione aqui o link para a issue que será resolvida com este PR.*

## Motivação

*Descreva as motivações deste PR*

Exemplo:

Tradução do tópico  **1 Guide Assumptions** da página **Getting Started with Rails**.

## Comentários

*Coloque comentários que considerar importante mencionar*

Exemplo:

https://guides.rubyonrails.org/getting_started.html#guide-assumptions

Traduzi apenas o primeiro e o segundo parágrafo do tópico.
