### PR TITLE
Icone de troca do tema não aparece no firefox corretamente

### DIFF
--- a/pt-BR/layout.html.erb
+++ b/pt-BR/layout.html.erb
@@ -143,7 +143,7 @@
     </div>
   </div>
   <div id="toggle">
-    <img class="icon">
+    <img alt="dark theme icon" class="icon">
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Motivação
![image](https://user-images.githubusercontent.com/14025084/121734397-19812d00-cacb-11eb-9846-42c97d3c89b0.png)

Icone não aparece da maneira esperada quando aberto no firefox.

## Comentários

Foi adicionado a propriedade `alt` no elemento, assim o icone aparece corretamente no firefox.

![image](https://user-images.githubusercontent.com/14025084/121734647-6ebd3e80-cacb-11eb-8c22-1990009b60eb.png)
![image](https://user-images.githubusercontent.com/14025084/121734686-7ed51e00-cacb-11eb-825d-f5e38efceb7d.png)
