### PR TITLE
Adiciona a relação de comentários na seção 9.1 do Getting Started

### DIFF
--- a/pt-BR/getting_started.md
+++ b/pt-BR/getting_started.md
@@ -1980,6 +1980,8 @@ Modifique o Modelo de artigo (article), `app/models/article.rb`, da seguinte for
 class Article < ApplicationRecord
   include Visible
 
+  has_many :comments, dependent: :destroy
+
   validates :title, presence: true
   validates :body, presence: true, length: { minimum: 10 }
 end


### PR DESCRIPTION
## Motivação

Estava fazendo o Blog da seção "Começando com Rails" e notei que no capítulo 9.1 esta faltando a relação de comentários no exemplo do código.

Link do Getting Started original: https://guides.rubyonrails.org/getting_started.html#deleting-associated-objects
```ruby
class Article < ApplicationRecord
  include Visible

  has_many :comments, dependent: :destroy

  validates :title, presence: true
  validates :body, presence: true, length: { minimum: 10 }
end 
```