### PR TITLE
Upgrading Ruby on Rails > 4. Upgrading from Rails 5.2 to Rails 6.0

### DIFF
--- a/pt-BR/upgrading_ruby_on_rails.md
+++ b/pt-BR/upgrading_ruby_on_rails.md
@@ -200,7 +200,7 @@ video.preview(resize_to_limit: [100, 100])
 video.preview(resize_to_fill: [100, 100])
 ```
 
-Upgrading from Rails 5.2 to Rails 6.0
+Atualizando do Rails 5.2 para o Rails 6.0
 -------------------------------------
 
 For more information on changes made to Rails 6.0 please see the [release notes](6_0_release_notes.html).


### PR DESCRIPTION
https://github.com/campuscode/rails-guides-pt-BR/issues/523

## Motivação

Tradução do tópico 4. Upgrading from Rails 5.2 to Rails 6.0 da página Upgrading Ruby on Rails.

## Comentários

Iniciando a tradução de mais um tópico.