### PR TITLE
Tradução para Active Support Core Extensions 4

### DIFF
--- a/pt-BR/active_support_core_extensions.md
+++ b/pt-BR/active_support_core_extensions.md
@@ -1060,7 +1060,7 @@ class D < C; end
 C.descendants # => [B, A, D]
 ```
 
-A ordem em que essas clásses são retornadas não é especificada.
+A ordem em que essas classes são retornadas não é especificada.
 
 NOTE: Definido em `active_support/core_ext/class/subclasses.rb`.
 


### PR DESCRIPTION
Close: https://github.com/campuscode/rails-guides-pt-BR/issues/615

## Motivação

Tradução do tópico 4. Extensions to Class da página Active Support Core Extensions.

