### PR TITLE
Active Model Basics > Melhorias e Correção de Traduções Faltando (1.4.2)

### DIFF
--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -411,7 +411,7 @@ pt-BR:
   activemodel:
     attributes:
       person:
-        name: "Nome"
+        name: 'Nome'
 ```
 
 ```ruby

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -423,11 +423,11 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
 
 * `app/models/person.rb`
 
-  ```ruby
-  class Person
-    include ActiveModel::Model
-  end
-  ```
+    ```ruby
+    class Person
+      include ActiveModel::Model
+    end
+    ```
 
 * `test/models/person_test.rb`
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -275,7 +275,7 @@ class EmailContact
 
   def deliver
     if valid?
-      # encaminha email
+      # envia email
     end
   end
 end

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -16,7 +16,7 @@ Após a leitura desse guia você saberá:
 
 ---
 
-## O que é _Active Model_?
+O que é _Active Model_?
 
 O Active Model é uma biblioteca que contém vários módulos utilizados para desenvolvimento de classes que precisam de algumas funções (`features`) existentes no Active Record.
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -9,10 +9,10 @@ O _Active Model_ permite que o _Action Pack Helpers_ interaja com os objetos rub
 
 Após a leitura desse guia você saberá:
 
-- Como um _Active Record_ se comporta.
-- Como _Callbacks_ e _Validações_ funcionam.
-- Como _serializers_ funcionam.
-- Como _Active Model_ integra com o framework de internacionalização (`i18n`) do Rails.
+* Como um _Active Record_ se comporta.
+* Como _Callbacks_ e _Validações_ funcionam.
+* Como _serializers_ funcionam.
+* Como _Active Model_ integra com o framework de internacionalização (`i18n`) do Rails.
 
 ---
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -431,8 +431,8 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
 
 * `test/models/person_test.rb`
 
-  ```ruby
-  require "test_helper"
+    ```ruby
+    require "test_helper"
 
   class PersonTest < ActiveSupport::TestCase
     include ActiveModel::Lint::Tests

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -422,7 +422,7 @@ Person.human_attribute_name('name') # => "Nome"
 
 O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a API do _model_ ativo.
 
-- `app/models/person.rb`
+* `app/models/person.rb`
 
   ```ruby
   class Person

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -1,21 +1,21 @@
 **NÃO LEIA ESTE ARQUIVO NO GITHUB, OS GUIAS SÃO PUBLICADOS NO https://guiarails.com.br.**
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
-Básico do _Active Model_
+Básico do *Active Model*
 ===================
 
 Esse guia deverá prover tudo que você precisa para começar a usar classes de modelo (`models`).
-O _Active Model_ permite que o _Action Pack Helpers_ interaja com os objetos ruby. O _Active model_ também auxilia a criação de _ORMs_ (mapeamento de objetos relacionais) para o uso fora do framework Rails.
+O *Active Model* permite que o *Action Pack Helpers* interaja com os objetos ruby. O *Active model* também auxilia a criação de *ORMs* (mapeamento de objetos relacionais) para o uso fora do framework Rails.
 
 Após a leitura desse guia você saberá:
-* Como um _Active Record_ se comporta.
-* Como _Callbacks_ e _Validações_ funcionam.
-* Como _serializers_ funcionam.
-* Como _Active Model_ integra com o framework de internacionalização (`i18n`) do Rails.
+* Como um *Active Record* se comporta.
+* Como *Callbacks* e *Validações* funcionam.
+* Como *serializers* funcionam.
+* Como *Active Model* integra com o framework de internacionalização (`i18n`) do Rails.
 
 --------------------------------------------------------------------------------
 
-O que é _Active Model_?
+O que é *Active Model*?
 -----------------------
 
 O Active Model é uma biblioteca que contém vários módulos utilizados para desenvolvimento de classes que precisam de algumas funções (`features`) existentes no Active Record.
@@ -196,7 +196,7 @@ irb> person.first_name_was
 => nil
 ```
 
-Rastreia o valor anterior e atual do atributo alterado. Retorna um _array_ se
+Rastreia o valor anterior e atual do atributo alterado. Retorna um *array* se
 alterado; caso contrário, retorna `nil`.
 
 ```irb
@@ -209,7 +209,7 @@ irb> person.last_name_change
 
 ### Validações
 
-O módulo `ActiveModel::Validations` adiciona a habilidade de validar objetos como no _Active Record_.
+O módulo `ActiveModel::Validations` adiciona a habilidade de validar objetos como no *Active Record*.
 
 ```ruby
 class Person
@@ -261,9 +261,9 @@ Person.model_name.route_key           # => "people"
 Person.model_name.singular_route_key  # => "person"
 ```
 
-### _Model_
+### *Model*
 
-O `ActiveModel::Model` adiciona a capacidade de uma classe trabalhar com o _Action Pack_ e _Action View_ imediatamente.
+O `ActiveModel::Model` adiciona a capacidade de uma classe trabalhar com o *Action Pack* e *Action View* imediatamente.
 
 ```ruby
 class EmailContact
@@ -282,12 +282,12 @@ end
 
 Ao incluir o `ActiveModel::Model`, você obtém alguns recursos como:
 
-- introspecção do nome de _model_
+- introspecção do nome de *model*
 - conversões
 - traduções
 - validações
 
-Também oferece a capacidade de inicializar um objeto com um hash de atributos, muito parecido com qualquer objeto _Active Record_.
+Também oferece a capacidade de inicializar um objeto com um hash de atributos, muito parecido com qualquer objeto *Active Record*.
 
 ```irb
 irb> email_contact = EmailContact.new(name: 'David', email: 'david@example.com', message: 'Hello World')
@@ -301,7 +301,7 @@ irb> email_contact.persisted?
 => false
 ```
 
-Qualquer classe que inclua `ActiveModel::Model` pode ser usada com `form_with`, `render` e quaisquer outros métodos auxiliares do _Action View_, assim como o _Active Record_ objetos.
+Qualquer classe que inclua `ActiveModel::Model` pode ser usada com `form_with`, `render` e quaisquer outros métodos auxiliares do *Action View*, assim como o *Active Record* objetos.
 
 ### Serialização
 
@@ -420,7 +420,7 @@ Person.human_attribute_name('name') # => "Nome"
 
 ### Testes de Lint
 
-O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a API do _model_ ativo.
+O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a API do *model* ativo.
 
 * `app/models/person.rb`
 
@@ -438,9 +438,9 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
     class PersonTest < ActiveSupport::TestCase
       include ActiveModel::Lint::Tests
 
-    setup do
-      @model = Person.new
-    end
+      setup do
+        @model = Person.new
+      end
     end
     ```
 
@@ -458,7 +458,7 @@ Finished in 0.024899s, 240.9735 runs/s, 1204.8677 assertions/s.
 6 runs, 30 assertions, 0 failures, 0 errors, 0 skips
 ```
 
-Não é necessário um objeto para implementar todas as APIs para trabalhar com _Action Pack_. Este módulo pretende apenas fornecer orientação caso você queira que todos recursos prontos para uso.
+Não é necessário um objeto para implementar todas as APIs para trabalhar com *Action Pack*. Este módulo pretende apenas fornecer orientação caso você queira que todos recursos prontos para uso.
 
 ### SecurePassword
 
@@ -466,9 +466,9 @@ O `ActiveModel::SecurePassword` fornece uma maneira de armazenar com segurança 
 
 #### Requerimentos
 
-O `ActiveModel::SecurePassword` depende de [`bcrypt`](https://github.com/codahale/bcrypt-ruby "BCrypt"),
+O `ActiveModel::SecurePassword` depende de [`bcrypt`](https://github.com/codahale/bcrypt-ruby 'BCrypt'),
 portanto, inclua esta `gem` no seu `Gemfile` para usar o` ActiveModel::SecurePassword` corretamente.
-Para fazer isso funcionar, o _model_ deve ter um acessador chamado `XXX_digest`.
+Para fazer isso funcionar, o *model* deve ter um acessador chamado `XXX_digest`.
 Onde `XXX` é o nome do atributo da sua senha desejada.
 As seguintes validações são adicionadas automaticamente:
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -1,16 +1,18 @@
 **NÃO LEIA ESTE ARQUIVO NO GITHUB, OS GUIAS SÃO PUBLICADOS NO https://guiarails.com.br.**
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
-Básico de *Active Model*
+Básico do *Active Model*
 ===================
+
 Esse guia deverá prover tudo que você precisa para começar a usar classes de modelo (`models`).
 O *Active Model* permite que o *Action Pack Helpers* interaja com os objetos ruby. O *Active model* também auxilia a criação de *ORMs* (mapeamento de objetos relacionais) para o uso fora do framework Rails.
 
 Após a leitura desse guia você saberá:
+
 * Como um *Active Record* se comporta.
-* Como Callbacks e Validações funcionam.
-* Como serializers funcionam.
-* Como *Active Model* integra com o framework de internacionalização(`i18n`) do Rails.
+* Como *Callbacks* e *Validações* funcionam.
+* Como *serializers* funcionam.
+* Como *Active Model* integra com o framework de internacionalização (`i18n`) do Rails.
 
 --------------------------------------------------------------------------------
 
@@ -73,12 +75,12 @@ class Person
 
   def update
     run_callbacks(:update) do
-      # This method is called when update is called on an object.
+      # Este método é chamado quando a atualização é chamada em um objeto.
     end
   end
 
   def reset_me
-    # This method is called when update is called on an object as a before_update callback is defined.
+    # Este método é chamado quando a atualização é chamada em um objeto, quando um retorno de chamada before_update é definida.
   end
 end
 ```
@@ -140,7 +142,7 @@ class Person
   end
 
   def save
-    # do save work...
+    # salva trabalho...
     changes_applied
   end
 end
@@ -176,7 +178,7 @@ irb> person.changes
 
 #### Atributos baseados em métodos de acesso
 
-Acompanhe se o atributo específico foi alterado ou não.
+Rastreia se o atributo específico foi alterado ou não.
 
 ```irb
 irb> person.first_name
@@ -187,7 +189,7 @@ irb> person.first_name_changed?
 => true
 ```
 
-Track the previous value of the attribute.
+Rastreia o valor anterior do atributo.
 
 ```irb
 # attr_name_was accessor
@@ -195,8 +197,7 @@ irb> person.first_name_was
 => nil
 ```
 
-Track both previous and current value of the changed attribute. Returns an array
-if changed, otherwise returns nil.
+Rastreia o valor anterior e atual do atributo alterado. Retorna um *array* se alterado, caso contrário, retorna *nil*.
 
 ```irb
 # attr_name_change
@@ -260,10 +261,10 @@ Person.model_name.i18n_key            # => :person
 Person.model_name.route_key           # => "people"
 Person.model_name.singular_route_key  # => "person"
 ```
+
 ### *Model*
 
 O `ActiveModel::Model` adiciona a capacidade de uma classe trabalhar com o *Action Pack* e *Action View* imediatamente.
-
 
 ```ruby
 class EmailContact
@@ -274,11 +275,12 @@ class EmailContact
 
   def deliver
     if valid?
-      # deliver email
+      # encaminha email
     end
   end
 end
 ```
+
 Ao incluir o `ActiveModel::Model`, você obtém alguns recursos como:
 
 - introspecção do nome de *model*
@@ -317,6 +319,7 @@ class Person
   end
 end
 ```
+
 Agora você pode acessar um Hash serializado do seu objeto usando o método `serializable_hash`.
 
 ```irb
@@ -347,6 +350,7 @@ class Person
   end
 end
 ```
+
 O método `as_json`, semelhante ao` serializable_hash`, fornece um Hash representando o modelo.
 
 ```irb
@@ -378,7 +382,7 @@ class Person
 end
 ```
 
-Agora é possível criar uma instância de `Person` e definir atributos usando` from_json`.
+Agora é possível criar uma instância de `Person` e definir atributos usando `from_json`.
 
 ```irb
 irb> json = { name: 'Bob' }.to_json
@@ -415,7 +419,7 @@ pt-BR:
 Person.human_attribute_name('name') # => "Nome"
 ```
 
-### Lint Tests
+### Testes de Lint
 
 O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a API do *model* ativo.
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -404,7 +404,7 @@ end
 
 Com o método `human_attribute_name`, você pode transformar nomes de atributos em um formato mais legível por humanos. O formato legível por humanos é definido nos seus arquivos de localidade.
 
-- config/locales/app.pt-BR.yml
+* config/locales/app.pt-BR.yml
 
 ```yaml
 pt-BR:

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -430,7 +430,7 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
   end
   ```
 
-- `test/models/person_test.rb`
+* `test/models/person_test.rb`
 
   ```ruby
   require "test_helper"

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -434,8 +434,8 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
     ```ruby
     require "test_helper"
 
-  class PersonTest < ActiveSupport::TestCase
-    include ActiveModel::Lint::Tests
+    class PersonTest < ActiveSupport::TestCase
+      include ActiveModel::Lint::Tests
 
     setup do
       @model = Person.new

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -13,7 +13,7 @@ Após a leitura desse guia você saberá:
 * Como _serializers_ funcionam.
 * Como _Active Model_ integra com o framework de internacionalização (`i18n`) do Rails.
 
----
+--------------------------------------------------------------------------------
 
 O que é _Active Model_?
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -440,8 +440,8 @@ O `ActiveModel::Lint::Tests` permite testar se um objeto é compatível com a AP
     setup do
       @model = Person.new
     end
-  end
-  ```
+    end
+    ```
 
 ```bash
 $ bin/rails test

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -16,6 +16,7 @@ Após a leitura desse guia você saberá:
 --------------------------------------------------------------------------------
 
 O que é _Active Model_?
+-----------------------
 
 O Active Model é uma biblioteca que contém vários módulos utilizados para desenvolvimento de classes que precisam de algumas funções (`features`) existentes no Active Record.
 

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -8,7 +8,6 @@ Esse guia deverá prover tudo que você precisa para começar a usar classes de 
 O _Active Model_ permite que o _Action Pack Helpers_ interaja com os objetos ruby. O _Active model_ também auxilia a criação de _ORMs_ (mapeamento de objetos relacionais) para o uso fora do framework Rails.
 
 Após a leitura desse guia você saberá:
-
 * Como um _Active Record_ se comporta.
 * Como _Callbacks_ e _Validações_ funcionam.
 * Como _serializers_ funcionam.

--- a/pt-BR/active_model_basics.md
+++ b/pt-BR/active_model_basics.md
@@ -1,7 +1,8 @@
 **NÃO LEIA ESTE ARQUIVO NO GITHUB, OS GUIAS SÃO PUBLICADOS NO https://guiarails.com.br.**
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
-# Básico do _Active Model_
+Básico do _Active Model_
+===================
 
 Esse guia deverá prover tudo que você precisa para começar a usar classes de modelo (`models`).
 O _Active Model_ permite que o _Action Pack Helpers_ interaja com os objetos ruby. O _Active model_ também auxilia a criação de _ORMs_ (mapeamento de objetos relacionais) para o uso fora do framework Rails.


### PR DESCRIPTION
Melhorias, e adicionado traduções que estavam faltando

Close: *https://github.com/campuscode/rails-guides-pt-BR/issues/648*

## Motivação

Melhorias e correções que estavam faltando na página **Active Model Basics**.
