### PR TITLE
Corrige typo na página de layout do guia

### DIFF
--- a/pt-BR/layout.html.erb
+++ b/pt-BR/layout.html.erb
@@ -112,7 +112,7 @@
           Você é incentivado a ajudar a melhorar a qualidade deste guia.
         </p>
         <p>
-          Por favor, contribua se vir qualquer erros, inclusive erros de digitação.
+          Por favor, contribua caso veja quaisquer erros, inclusive erros de digitação.
           Para começar, você pode ler nossa sessão de <%= link_to 'contribuindo com a documentação', 'https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation' %>.
         </p>
         <p>


### PR DESCRIPTION
Close: [*#703*](https://github.com/campuscode/rails-guides-pt-BR/issues/703)

## Motivação

Corrigir erros de digitação e concordância na parte de Feedback do arquivo de layout
