### PR TITLE
tradução de como o I18n funciona no Ruby on Rails

### DIFF
--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -31,17 +31,17 @@ Este documento o guiará pela API I18n e contém um tutorial sobre como internac
 
 NOTE: The Ruby I18n framework provides you with all necessary means for internationalization/localization of your Rails application. You may, also use various gems available to add additional functionality or features. See the [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) for more information.
 
-How I18n in Ruby on Rails Works
+Como o I18n funciona no Ruby on Rails
 -------------------------------
 
-Internationalization is a complex problem. Natural languages differ in so many ways (e.g. in pluralization rules) that it is hard to provide tools for solving all problems at once. For that reason the Rails I18n API focuses on:
+Internacionalização é um problema complexo. Idiomas naturais são diferentes de tantas maneiras (por exemplo, nas regras do plural) que é difícil fazer ferramentas para solucionar todos os problemas de uma vez só. Por este motivo a API I18n do Rails foca em:
 
-* providing support for English and similar languages out of the box
-* making it easy to customize and extend everything for other languages
+* dar suporte para o inglês e outros idiomas parecidos prontos para uso
+* facilizar a personalização e estender tudo para outros idiomas
 
-As part of this solution, **every static string in the Rails framework** - e.g. Active Record validation messages, time and date formats - **has been internationalized**. _Localization_ of a Rails application means defining translated values for these strings in desired languages.
+Como parte desta solução, **toda string estática no framework de Rails** - por exemplo, validações de mensagens no Active Record, formatos de hora e data - **foram internacionalizados**. _Localization_ de uma aplicação Rails significa difinir valores traduzidos para essas strings nos idiomas desejados.
 
-To localize store and update _content_ in your application (e.g. translate blog posts), see the [Translating model content](#translating-model-content) section.
+Para localizar armazenamento e atualizar _content_ na sua aplicação (por exemplo, traduzir posts de blogs), veja a sessão [Traduzindo o conteúdo do model](#translating-model-content).
 
 ### The Overall Architecture of the Library
 


### PR DESCRIPTION
Close: *https://guiarails.com.br/i18n#how-i18n-in-ruby-on-rails-works*

## Motivação

Comecei a tradução dos tópicos de tradução do Rails usando a gem I18n, tenho interesse em aprender mais sobre a documentação do I18n, pois ja utilizei em um projeto escolar.

Exemplo:

Tradução do tópico  **1 How I18n in Ruby on Rails Works** da página **API de Internacionalização do Rails(I18n)**.

## Comentários

https://guides.rubyonrails.org/getting_started.html#guide-assumptions

Traduzi apenas o primeiro e o segundo parágrafo do tópico.
