### PR TITLE
Tradução I18n > 1. How I18n in Ruby on Rails Works

### DIFF
--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -31,58 +31,58 @@ Este documento o guiará pela API I18n e contém um tutorial sobre como internac
 
 NOTE: O *framework* Ruby I18n fornece todas os meios necessários para internacionalização/localização da sua aplicação Rails. Você também pode usar várias *gems* disponíveis para adicionar funcionalidades ou recursos adicionais. Veja [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) para mais informações.
 
-Como I18n funciona no Ruby on Rails
+Como o I18n funciona no Ruby on Rails
 -------------------------------
 
-Internationalization is a complex problem. Natural languages differ in so many ways (e.g. in pluralization rules) that it is hard to provide tools for solving all problems at once. For that reason the Rails I18n API focuses on:
+A internacionalização é um problema complexo. As línguas diferem de muitas maneiras (por exemplo, nas regras de pluralização), sendo difícil fornecer ferramentas para resolver todos os problemas de uma vez. Por esse motivo, a API I18n do Rails concentra-se em:
 
-* providing support for English and similar languages out of the box
-* making it easy to customize and extend everything for other languages
+* fornecer suporte para o inglês e línguas similares por padrão
+* facilitar a personalização e extensão de tudo para outras línguas
 
-As part of this solution, **every static string in the Rails framework** - e.g. Active Record validation messages, time and date formats - **has been internationalized**. _Localization_ of a Rails application means defining translated values for these strings in desired languages.
+Como parte dessa solução, **cada string estática no framework Rails** - por exemplo, mensagens de validação do Active Record, formatos de data e hora - **foi internacionalizada**. _Localização_ de uma aplicação Rails significa definir valores traduzidos para essas strings nos idiomas desejados.
 
-To localize, store, and update _content_ in your application (e.g. translate blog posts), see the [Translating model content](#translating-model-content) section.
+Para localizar, armazenar e atualizar _conteúdo_ em sua aplicação (por exemplo, traduzir postagens de blog), consulte a seção [Traduzindo Conteúdo do Model](#translating-model-content).
 
-### The Overall Architecture of the Library
+### A Arquitetura Geral da Biblioteca
 
-Thus, the Ruby I18n gem is split into two parts:
+Assim, a gem Ruby I18n é dividida em duas partes:
 
-* The public API of the i18n framework - a Ruby module with public methods that define how the library works
-* A default backend (which is intentionally named _Simple_ backend) that implements these methods
+* A API pública do framework i18n - um módulo Ruby com métodos públicos que definem como a biblioteca funciona
+* Um backend padrão (intencionalmente chamado de backend _Simple_) que implementa esses métodos
 
-As a user you should always only access the public methods on the I18n module, but it is useful to know about the capabilities of the backend.
+Como usuário, você deve sempre acessar apenas os métodos públicos no módulo I18n, mas é útil conhecer as capacidades do backend.
 
-NOTE: It is possible to swap the shipped Simple backend with a more powerful one, which would store translation data in a relational database, GetText dictionary, or similar. See section [Using different backends](#using-different-backends) below.
+NOTE: É possível substituir o backend Simple fornecido por um mais poderoso, que armazenaria dados de tradução em um banco de dados relacional, dicionário GetText, ou similar. Consulte a seção [Usando Backends Diferentes](#using-different-backends) abaixo.
 
-### The Public I18n API
+### A API Pública I18n
 
-The most important methods of the I18n API are:
+Os métodos mais importantes da API I18n são:
 
 ```ruby
-translate # Lookup text translations
-localize  # Localize Date and Time objects to local formats
+translate # Pesquisar traduções de texto
+localize  # Localizar objetos de Data e Hora nos formatos locais
 ```
 
-These have the aliases #t and #l so you can use them like this:
+Eles têm os aliases #t e #l, para que você possa usá-los assim:
 
 ```ruby
 I18n.t 'store.title'
 I18n.l Time.now
 ```
 
-There are also attribute readers and writers for the following attributes:
+Também há métodos de leitura e escrita para os seguintes atributos:
 
 ```ruby
-load_path                 # Announce your custom translation files
-locale                    # Get and set the current locale
-default_locale            # Get and set the default locale
-available_locales         # Permitted locales available for the application
-enforce_available_locales # Enforce locale permission (true or false)
-exception_handler         # Use a different exception_handler
-backend                   # Use a different backend
+load_path                 # Anuncie seus arquivos de tradução personalizados
+locale                    # Obtenha e defina o idioma atual
+default_locale            # Obtenha e defina o idioma padrão
+available_locales         # Locais permitidos disponíveis para a aplicação
+enforce_available_locales # Reforce a permissão de idioma (true ou false)
+exception_handler         # Use um manipulador de exceção diferente
+backend                   # Use um backend diferente
 ```
 
-So, let's internationalize a simple Rails application from the ground up in the next chapters!
+Então, vamos internacionalizar uma aplicação Rails simples do zero nos próximos capítulos!
 
 Setup the Rails Application for Internationalization
 ----------------------------------------------------

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -31,7 +31,7 @@ Este documento o guiará pela API I18n e contém um tutorial sobre como internac
 
 NOTE: O *framework* Ruby I18n fornece todas os meios necessários para internacionalização/localização da sua aplicação Rails. Você também pode usar várias *gems* disponíveis para adicionar funcionalidades ou recursos adicionais. Veja [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) para mais informações.
 
-How I18n in Ruby on Rails Works
+Como I18n funciona no Ruby on Rails
 -------------------------------
 
 Internationalization is a complex problem. Natural languages differ in so many ways (e.g. in pluralization rules) that it is hard to provide tools for solving all problems at once. For that reason the Rails I18n API focuses on:


### PR DESCRIPTION
Close: [How I18n in Ruby on Rails Works](https://github.com/campuscode/rails-guides-pt-BR/issues/845)

## Motivação

Iniciar tradução do capítulo sobre I18n.

Tradução do tópico  **[1 How I18n in Ruby on Rails Works](https://guides.rubyonrails.org/i18n.html#how-i18n-in-ruby-on-rails-works)** da página **[API de Internacionalização do Rails (I18n)](https://guiarails.com.br/i18n.html)**.
