### PR TITLE
Tradução I18n > 2.Setup the Rails Application for Internationalization

### DIFF
--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -87,64 +87,63 @@ Então, vamos internacionalizar uma aplicação Rails simples do zero nos próxi
 Configurando a Aplicação Rails para Internacionalização
 -------------------------------------------------------
 
-There are a few steps to get up and running with I18n support for a Rails application.
+Há alguns passos para começar a usar o suporte à internacionalização (I18n) em uma aplicação Rails.
 
-### Configure the I18n Module
+### Configurando o Módulo I18n
 
-Following the _convention over configuration_ philosophy, Rails I18n provides reasonable default translation strings. When different translation strings are needed, they can be overridden.
+Seguindo a filosofia de _convenção sobre configuração_, o Rails I18n fornece algumas strings com tradução padrão. Quando são necessárias strings com tradução diferentes, elas podem ser sobrescritas.
 
-Rails adds all `.rb` and `.yml` files from the `config/locales` directory to the **translations load path**, automatically.
+O Rails adiciona todos os arquivos `.rb` e `.yml` do diretório `config/locales` ao **caminho de carregamento de traduções** automaticamente.
 
-The default `en.yml` locale in this directory contains a sample pair of translation strings:
+O arquivo padrão `en.yml` neste diretório inclui um par de exemplos de strings para tradução:
 
 ```yaml
 en:
   hello: "Hello world"
 ```
 
-This means, that in the `:en` locale, the key _hello_ will map to the _Hello world_ string. Every string inside Rails is internationalized in this way, see for instance Active Model validation messages in the [`activemodel/lib/active_model/locale/en.yml`](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/locale/en.yml) file or time and date formats in the [`activesupport/lib/active_support/locale/en.yml`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml) file. You can use YAML or standard Ruby Hashes to store translations in the default (Simple) backend.
+Isso significa que, na localidade `:en`, a chave _hello_ será mapeada para a string _Hello world_. Cada *string* dentro do Rails é internacionalizada dessa maneira. Consulte, por exemplo, as mensagens de validação do Active Model no arquivo [activemodel/lib/active_model/locale/en.yml](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/locale/en.yml) ou os formatos de hora e data no arquivo [`activesupport/lib/active_support/locale/en.yml`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml). Você pode usar YAML ou hashes Ruby padrão para armazenar traduções no *backend* padrão (Simple).
 
-The I18n library will use **English** as a **default locale**, i.e. if a different locale is not set, `:en` will be used for looking up translations.
+A biblioteca I18n usará o **inglês** como **localidade padrão**. Ou seja, se uma localidade diferente não estiver configurada, `:en` será usada para procurar traduções.
 
-NOTE: The i18n library takes a **pragmatic approach** to locale keys (after [some discussion](https://groups.google.com/g/rails-i18n/c/FN7eLH2-lHA)), including only the _locale_ ("language") part, like `:en`, `:pl`, not the _region_ part, like `:"en-US"` or `:"en-GB"`, which are traditionally used for separating "languages" and "regional setting" or "dialects". Many international applications use only the "language" element of a locale such as `:cs`, `:th`, or `:es` (for Czech, Thai, and Spanish). However, there are also regional differences within different language groups that may be important. For instance, in the `:"en-US"` locale you would have $ as a currency symbol, while in `:"en-GB"`, you would have £. Nothing stops you from separating regional and other settings in this way: you just have to provide full "English - United Kingdom" locale in a `:"en-GB"` dictionary.
+NOTE: A biblioteca I18n adota uma **abordagem pragmática** para as chaves de localidade (após [algumas discussões](https://groups.google.com/g/rails-i18n/c/FN7eLH2-lHA)), incluindo apenas a parte da _localidade_ ("idioma"), como `:en`, `:pl`, não a parte da _região_, como `:"en-US"` ou `:"en-GB"`, que são tradicionalmente usadas para separar "idiomas" e "configurações regionais" ou "dialetos". Muitas aplicações internacionais usam apenas o elemento "idioma" de uma localidade, como  `:cs`, `:th`, ou `:es`  (para tcheco, tailandês e espanhol). No entanto, também existem diferenças regionais dentro de diferentes grupos de idiomas que podem ser importantes. Por exemplo, na localidade `:"en-US"`, você teria $ como símbolo de moeda, enquanto na `:"en-GB"`, você teria £. Nada impede você de separar configurações regionais e outras dessa maneira: você só precisa fornecer a localidade completa "Inglês - Reino Unido" em um dicionário `:"en-GB"`.
 
-The **translations load path** (`I18n.load_path`) is an array of paths to files that will be loaded automatically. Configuring this path allows for customization of translations directory structure and file naming scheme.
+O **caminho de carregamento de traduções* (`I18n.load_path`) é um *array* de caminhos para arquivos que serão carregados automaticamente. Configurar este caminho permite a personalização da estrutura do diretório de traduções e do esquema de nomeação de arquivos.
 
-NOTE: The backend lazy-loads these translations when a translation is looked up for the first time. This backend can be swapped with something else even after translations have already been announced.
+NOTE: O *backend* carrega essas traduções de forma lenta quando uma tradução é consultada pela primeira vez. Esse *backend* pode ser trocado por outro mesmo depois que as traduções já foram anunciadas.
 
-You can change the default locale as well as configure the translations load paths in `config/application.rb` as follows:
+Você pode alterar a localidade padrão, bem como configurar os caminhos de carregamento de traduções em `config/application.rb` da seguinte forma:
 
 ```ruby
 config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
 config.i18n.default_locale = :de
 ```
-
-The load path must be specified before any translations are looked up. To change the default locale from an initializer instead of `config/application.rb`:
+O caminho de carregamento deve ser especificado antes de qualquer consulta de tradução. Para alterar a localidade padrão a partir de um inicializador em vez de `config/application.rb`:
 
 ```ruby
 # config/initializers/locale.rb
 
-# Where the I18n library should search for translation files
+# Onde a biblioteca I18n deve procurar arquivos de tradução
 I18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
 
-# Permitted locales available for the application
+# Localidades permitidas disponíveis para a aplicação
 I18n.available_locales = [:en, :pt]
 
-# Set default locale to something other than :en
+# Definir localidade padrão para algo diferente de :en
 I18n.default_locale = :pt
 ```
 
-Note that appending directly to `I18n.load_path` instead of to the application's configured i18n will _not_ override translations from external gems.
+Note que anexar diretamente a `I18n.load_path` em vez de à configuração i18n da aplicação _não_ substituirá traduções de gems externas.
 
-### Managing the Locale across Requests
+### Gerenciando a Localidade entre Requisições
 
-A localized application will likely need to provide support for multiple locales. To accomplish this, the locale should be set at the beginning of each request so that all strings are translated using the desired locale during the lifetime of that request.
+Uma aplicação localizada provavelmente precisará oferecer suporte a várias localidades. Para isso, a localidade deve ser definida no início de cada requisição para que todas as *strings* sejam traduzidas usando a localidade desejada durante a vida útil dessa requisição.
 
-The default locale is used for all translations unless `I18n.locale=` or `I18n.with_locale` is used.
+A localidade padrão é usada para todas as traduções, a menos que `I18n.locale=` ou `I18n.with_locale` seja usado.
 
-`I18n.locale` can leak into subsequent requests served by the same thread/process if it is not consistently set in every controller. For example executing `I18n.locale = :es` in one POST requests will have effects for all later requests to controllers that don't set the locale, but only in that particular thread/process. For that reason, instead of `I18n.locale =` you can use `I18n.with_locale` which does not have this leak issue.
+A `I18n.locale` pode vazar para requisições subsequentes servidas pela mesma thread/processo se não for consistentemente definida em cada *controller*. Por exemplo, executar `I18n.locale = :es` em uma requisição POST terá efeitos para todas as requisições posteriores aos controllers que não definem a localidade, mas apenas nessa thread/processo específico. Por esse motivo, em vez de `I18n.locale =` você pode usar `I18n.with_locale`, que não tem esse problema de vazamento.
 
-The locale can be set in an `around_action` in the `ApplicationController`:
+A localidade pode ser definida em um `around_action` no `ApplicationController`:
 
 ```ruby
 around_action :switch_locale
@@ -155,20 +154,20 @@ def switch_locale(&action)
 end
 ```
 
-This example illustrates this using a URL query parameter to set the locale (e.g. `http://example.com/books?locale=pt`). With this approach, `http://localhost:3000?locale=pt` renders the Portuguese localization, while `http://localhost:3000?locale=de` loads a German localization.
+Este exemplo ilustra isso usando um parâmetro de consulta de URL para definir a localidade (por exemplo, `http://example.com/books?locale=pt`). Com essa abordagem, `http://localhost:3000?locale=pt` renderiza a localização em português, enquanto `http://localhost:3000?locale=de` carrega a localização em alemão.
 
-The locale can be set using one of many different approaches.
+A localidade pode ser definida de várias maneiras diferentes.
 
-#### Setting the Locale from the Domain Name
+#### Definindo a Localidade a partir do Nome do Domínio
 
-One option you have is to set the locale from the domain name where your application runs. For example, we want `www.example.com` to load the English (or default) locale, and `www.example.es` to load the Spanish locale. Thus the _top-level domain name_ is used for locale setting. This has several advantages:
+Uma opção que você tem é definir a localidade a partir do nome de domínio onde sua aplicação está em execução. Por exemplo, queremos que `www.example.com` carregue a localidade em inglês (ou padrão) e `www.example.es` carregue a localidade em espanhol. Assim, o nome de _domínio de nível superior_ é usado para a definição da localidade. Isso tem várias vantagens:
 
-* The locale is an _obvious_ part of the URL.
-* People intuitively grasp in which language the content will be displayed.
-* It is very trivial to implement in Rails.
-* Search engines seem to like that content in different languages lives at different, inter-linked domains.
+* A localidade é uma parte _óbvia_ da URL.
+* As pessoas compreendem intuitivamente em qual idioma o conteúdo será exibido.
+* É muito trivial de implementar no Rails.
+* Os motores de busca parecem gostar de conteúdo em diferentes idiomas em domínios diferentes e interligados.
 
-You can implement it like this in your `ApplicationController`:
+Você pode implementar isso da seguinte forma no seu `ApplicationController`:
 
 ```ruby
 around_action :switch_locale
@@ -178,52 +177,51 @@ def switch_locale(&action)
   I18n.with_locale(locale, &action)
 end
 
-# Get locale from top-level domain or return +nil+ if such locale is not available
-# You have to put something like:
+# Obtenha o idioma do domínio de nível superior ou retorne +nil+ se esse idioma não estiver disponível
+# Você precisa adicionar algo como:
 #   127.0.0.1 application.com
 #   127.0.0.1 application.it
 #   127.0.0.1 application.pl
-# in your /etc/hosts file to try this out locally
+# no seu arquivo /etc/hosts para testar isso localmente
 def extract_locale_from_tld
   parsed_locale = request.host.split('.').last
   I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
 
-We can also set the locale from the _subdomain_ in a very similar way:
+Também podemos definir o idioma a partir do _subdomínio_ de uma maneira muito semelhante:
 
 ```ruby
-# Get locale code from request subdomain (like http://it.application.local:3000)
-# You have to put something like:
+# Obtenha o código do idioma do subdomínio da solicitação (como http://it.application.local:3000)
+# Você precisa adicionar algo como:
 #   127.0.0.1 gr.application.local
-# in your /etc/hosts file to try this out locally
+# no seu arquivo /etc/hosts para testar isso localmente
 def extract_locale_from_subdomain
   parsed_locale = request.subdomains.first
   I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
-
-If your application includes a locale switching menu, you would then have something like this in it:
+Se sua aplicação incluir um menu de troca de idioma, você terá algo assim:
 
 ```ruby
 link_to("Deutsch", "#{APP_CONFIG[:deutsch_website_url]}#{request.env['PATH_INFO']}")
 ```
+supondo que você defina `APP_CONFIG[:deutsch_website_url]` para algum valor como `http://www.application.de`.
 
-assuming you would set `APP_CONFIG[:deutsch_website_url]` to some value like `http://www.application.de`.
+Esta solução tem as vantagens mencionadas anteriormente, no entanto, você pode não conseguir ou não querer fornecer diferentes localizações ("versões de idioma") em domínios diferentes. A solução mais óbvia seria incluir o código do idioma nos parâmetros da URL (ou caminho da solicitação).
 
-This solution has aforementioned advantages, however, you may not be able or may not want to provide different localizations ("language versions") on different domains. The most obvious solution would be to include locale code in the URL params (or request path).
+#### Definindo o Idioma a partir de Parâmetros da URL
 
-#### Setting the Locale from URL Params
+A maneira mais comum de definir (e passar) o idioma seria incluí-lo nos parâmetros da URL, como fizemos no `I18n.with_locale(params[:locale], &action)` _around_action_ no primeiro exemplo. Gostaríamos de ter URLs como www.example.com/books?locale=ja ou www.example.com/ja/books neste caso.
 
-The most usual way of setting (and passing) the locale would be to include it in URL params, as we did in the `I18n.with_locale(params[:locale], &action)` _around_action_ in the first example. We would like to have URLs like `www.example.com/books?locale=ja` or `www.example.com/ja/books` in this case.
 
-This approach has almost the same set of advantages as setting the locale from the domain name: namely that it's RESTful and in accord with the rest of the World Wide Web. It does require a little bit more work to implement, though.
+Essa abordagem compartilha quase o mesmo conjunto de vantagens de definir o idioma a partir do nome do domínio, principalmente por ser RESTful e estar em conformidade com o restante da World Wide Web. No entanto, demanda um pouco mais de esforço para ser implementada.
 
-Getting the locale from `params` and setting it accordingly is not hard; including it in every URL and thus **passing it through the requests** is. To include an explicit option in every URL, e.g. `link_to(books_url(locale: I18n.locale))`, would be tedious and probably impossible, of course.
+Obter o idioma de `params` e defini-lo de acordo não é difícil; incluí-lo em cada URL e assim **passá-lo por meio das solicitações é**. Incluir uma opção explícita em cada URL, por exemplo, `link_to(books_url(locale: I18n.locale))`, seria tedioso e provavelmente impossível, é claro.
 
-Rails contains infrastructure for "centralizing dynamic decisions about the URLs" in its [`ApplicationController#default_url_options`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-default_url_options), which is useful precisely in this scenario: it enables us to set "defaults" for [`url_for`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for) and helper methods dependent on it (by implementing/overriding `default_url_options`).
+O Rails contém infraestrutura para "centralizar decisões dinâmicas sobre os URLs" em seu [`ApplicationController#default_url_options`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-default_url_options), que é útil precisamente nesse cenário: ele nos permite definir "padrões" para [`url_for`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for) e métodos auxiliares dependentes dele (implementando/substituindo `default_url_options`).
 
-We can include something like this in our `ApplicationController` then:
+Podemos incluir algo assim no nosso `ApplicationController` então:
 
 ```ruby
 # app/controllers/application_controller.rb
@@ -231,11 +229,11 @@ def default_url_options
   { locale: I18n.locale }
 end
 ```
+Todo método auxiliar dependente de `url_for` (por exemplo, auxiliares para rotas nomeadas como `root_path` ou `root_url`, rotas de recursos como `books_path` ou `books_url`, etc.) agora incluirá **automaticamente o idioma na string de consulta**, como isto: `http://localhost:3001/?locale=ja`.
 
-Every helper method dependent on `url_for` (e.g. helpers for named routes like `root_path` or `root_url`, resource routes like `books_path` or `books_url`, etc.) will now **automatically include the locale in the query string**, like this: `http://localhost:3001/?locale=ja`.
+Você pode estar satisfeito com isso. No entanto, impacta a legibilidade das URLs, quando o idioma "pendura" no final de cada URL na sua aplicação. Além disso, do ponto de vista arquitetônico, o idioma geralmente está hierarquicamente acima das outras partes do domínio da aplicação: e as URLs devem refletir isso.
 
-You may be satisfied with this. It does impact the readability of URLs, though, when the locale "hangs" at the end of every URL in your application. Moreover, from the architectural standpoint, locale is usually hierarchically above the other parts of the application domain: and URLs should reflect this.
-
+Provavelmente, você quer que as URLs se pareçam com isso: `http://www.example.com/en/books` (que carrega o idioma inglês) e `http://www.example.com/nl/books` (que carrega o idioma holandês). Isso é possível com a estratégia de "sobrepor `default_url_options`" mencionada acima: você só precisa configurar suas rotas com [`scope`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Scoping.html):
 You probably want URLs to look like this: `http://www.example.com/en/books` (which loads the English locale) and `http://www.example.com/nl/books` (which loads the Dutch locale). This is achievable with the "over-riding `default_url_options`" strategy from above: you just have to set up your routes with [`scope`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Scoping.html):
 
 ```ruby
@@ -245,11 +243,11 @@ scope "/:locale" do
 end
 ```
 
-Now, when you call the `books_path` method you should get `"/en/books"` (for the default locale). A URL like `http://localhost:3001/nl/books` should load the Dutch locale, then, and following calls to `books_path` should return `"/nl/books"` (because the locale changed).
+Agora, quando você chama o método `books_path`, você deve obter `"/en/books"` (para o idioma padrão). Uma URL como `http://localhost:3001/nl/books` deve carregar o idioma holandês e chamadas subsequentes para `books_path` devem retornar `"/nl/books"` (porque o idioma mudou).
 
-WARNING. Since the return value of `default_url_options` is cached per request, the URLs in a locale selector cannot be generated invoking helpers in a loop that sets the corresponding `I18n.locale` in each iteration. Instead, leave `I18n.locale` untouched, and pass an explicit `:locale` option to the helper, or edit `request.original_fullpath`.
+CUIDADO. Como o valor de retorno de `default_url_options` é armazenado em cache por solicitação, as URLs em um seletor de idioma não podem ser geradas chamando auxiliares em um _loop_ que define o `I18n.locale` correspondente em cada iteração. Em vez disso, deixe `I18n.locale` intocado e passe uma opção explícita `:locale` para o auxiliar, ou edite `request.original_fullpath`.
 
-If you don't want to force the use of a locale in your routes you can use an optional path scope (denoted by the parentheses) like so:
+Se você não deseja forçar o uso de um idioma nas suas rotas, pode usar um escopo de caminho opcional (indicado pelos parênteses) assim:
 
 ```ruby
 # config/routes.rb
@@ -257,25 +255,24 @@ scope "(:locale)", locale: /en|nl/ do
   resources :books
 end
 ```
+Com essa abordagem, você não receberá um `Routing Error` ao acessar seus recursos, como  `http://localhost:3001/books` sem um idioma. Isso é útil quando você deseja usar o idioma padrão quando não especificado.
 
-With this approach you will not get a `Routing Error` when accessing your resources such as `http://localhost:3001/books` without a locale. This is useful for when you want to use the default locale when one is not specified.
 
-Of course, you need to take special care of the root URL (usually "homepage" or "dashboard") of your application. A URL like `http://localhost:3001/nl` will not work automatically, because the `root to: "dashboard#index"` declaration in your `routes.rb` doesn't take locale into account. (And rightly so: there's only one "root" URL.)
+Claro, você precisa ter um cuidado especial com a URL raiz (geralmente "homepage" ou "dashboard") da sua aplicação. Uma URL como `http://localhost:3001/nl` não funcionará automaticamente, porque a declaração `root to: "dashboard#index"` no seu `routes.rb` não leva em consideração o idioma. (E com razão: há apenas uma URL "root").
 
-You would probably need to map URLs like these:
+Você provavelmente precisaria mapear URLs como estas:
 
 ```ruby
 # config/routes.rb
 get '/:locale' => 'dashboard#index'
 ```
+Tenha um cuidado especial com a **ordem das suas rotas**, para que essa declaração de rota não "anule" outras. (Você pode querer adicioná-la diretamente antes da declaração `root :to`.)
 
-Do take special care about the **order of your routes**, so this route declaration does not "eat" other ones. (You may want to add it directly before the `root :to` declaration.)
+NOTA: Dê uma olhada em várias gems que simplificam o trabalho com rotas:  [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
 
-NOTE: Have a look at various gems which simplify working with routes: [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
+#### Definindo o Idioma a partir das Preferências do Usuário
 
-#### Setting the Locale from User Preferences
-
-An application with authenticated users may allow users to set a locale preference through the application's interface. With this approach, a user's selected locale preference is persisted in the database and used to set the locale for authenticated requests by that user.
+Uma aplicação com usuários autenticados pode permitir que os usuários definam uma preferência de idioma por meio da interface da aplicação. Com essa abordagem, a preferência de idioma selecionada pelo usuário é persistida no banco de dados e usada para definir o idioma para solicitações autenticadas por esse usuário.
 
 ```ruby
 around_action :switch_locale
@@ -286,15 +283,15 @@ def switch_locale(&action)
 end
 ```
 
-#### Choosing an Implied Locale
+#### Escolhendo um Idioma Implícito
 
-When an explicit locale has not been set for a request (e.g. via one of the above methods), an application should attempt to infer the desired locale.
+Quando um idioma explícito não foi definido para uma solicitação (por exemplo, por meio de um dos métodos acima), a aplicação deve tentar inferir o idioma desejado.
 
-##### Inferring Locale from the Language Header
+##### Inferindo o Idioma do Cabeçalho de Idioma
 
-The `Accept-Language` HTTP header indicates the preferred language for request's response. Browsers [set this header value based on the user's language preference settings](https://www.w3.org/International/questions/qa-lang-priorities), making it a good first choice when inferring a locale.
+O cabeçalho HTTP `Accept-Language` indica o idioma preferido para a resposta da solicitação. Navegadores [configuram esse valor de cabeçalho com base nas configurações de preferência de idioma do usuário](https://www.w3.org/International/questions/qa-lang-priorities), tornando-o uma boa escolha inicial ao inferir um idioma.
 
-A trivial implementation of using an `Accept-Language` header would be:
+Uma implementação trivial usando um cabeçalho `Accept-Language` ser
 
 ```ruby
 def switch_locale(&action)
@@ -310,18 +307,17 @@ private
   end
 ```
 
+Na prática, é necessário um código mais robusto para fazer isso de forma confiável. A biblioteca [http_accept_language](https://github.com/iain/http_accept_language/tree/master) de Iain Hecker ou o middleware Rack [locale](https://github.com/rack/rack-contrib/blob/master/lib/rack/contrib/locale.rb) de Ryan Tomayko oferecem soluções para esse problema.
 
-In practice, more robust code is necessary to do this reliably. Iain Hecker's [http_accept_language](https://github.com/iain/http_accept_language/tree/master) library or Ryan Tomayko's [locale](https://github.com/rack/rack-contrib/blob/master/lib/rack/contrib/locale.rb) Rack middleware provide solutions to this problem.
+##### Inferindo o Idioma a partir da Geolocalização por IP
 
-##### Inferring the Locale from IP Geolocation
+O endereço IP do cliente que faz a solicitação pode ser usado para inferir a região do cliente e, portanto, seu idioma. Serviços como [GeoLite2 Country](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) ou gems como [geocoder](https://github.com/alexreisner/geocoder) podem ser usados para implementar essa abordagem.
 
-The IP address of the client making the request can be used to infer the client's region and thus their locale. Services such as [GeoLite2 Country](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) or gems like [geocoder](https://github.com/alexreisner/geocoder) can be used to implement this approach.
+Em geral, essa abordagem é muito menos confiável do que usar o cabeçalho de idioma e não é recomendada para a maioria das aplicações web.
 
-In general, this approach is far less reliable than using the language header and is not recommended for most web applications.
+#### Armazenando o Idioma a partir da Sessão ou *Cookies*
 
-#### Storing the Locale from the Session or Cookies
-
-WARNING: You may be tempted to store the chosen locale in a _session_ or a *cookie*. However, **do not do this**. The locale should be transparent and a part of the URL. This way you won't break people's basic assumptions about the web itself: if you send a URL to a friend, they should see the same page and content as you. A fancy word for this would be that you're being [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Read more about the RESTful approach in [Stefan Tilkov's articles](https://www.infoq.com/articles/rest-introduction). Sometimes there are exceptions to this rule and those are discussed below.
+CUIDADO: Você pode ser tentado a armazenar o idioma escolhido em uma _sessão_ ou em um *cookie*. No entanto, **não faça isso**. O idioma deve ser transparente e fazer parte da URL. Dessa forma, você não quebrará as suposições básicas das pessoas sobre a web: se você enviar uma URL a um amigo, eles deveriam ver a mesma página e conteúdo que você. Um termo sofisticado para isso seria que você está sendo [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Leia mais sobre a abordagem RESTful nos [artigos de Stefan Tilkov](https://www.infoq.com/articles/rest-introduction). Às vezes, há exceções a essa regra, e essas são discutidas abaixo.
 
 Internationalization and Localization
 -------------------------------------

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -84,8 +84,8 @@ backend                   # Use um backend diferente
 
 Então, vamos internacionalizar uma aplicação Rails simples do zero nos próximos capítulos!
 
-Setup the Rails Application for Internationalization
-----------------------------------------------------
+Configurando a Aplicação Rails para Internacionalização
+-------------------------------------------------------
 
 There are a few steps to get up and running with I18n support for a Rails application.
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -91,18 +91,18 @@ Há alguns passos para começar a usar o suporte à internacionalização (I18n)
 
 ### Configurando o Módulo I18n
 
-Seguindo a filosofia de _convenção sobre configuração_, o Rails I18n fornece algumas strings com tradução padrão. Quando são necessárias strings com tradução diferentes, elas podem ser sobrescritas.
+Seguindo a filosofia de _convenção sobre configuração_, o Rails I18n fornece algumas _strings_ com tradução padrão. Quando são necessárias _strings_ com tradução diferentes, elas podem ser sobrescritas.
 
 O Rails adiciona todos os arquivos `.rb` e `.yml` do diretório `config/locales` ao **caminho de carregamento de traduções** automaticamente.
 
-O arquivo padrão `en.yml` neste diretório inclui um par de exemplos de strings para tradução:
+O arquivo padrão `en.yml` neste diretório inclui um par de exemplos de _strings_ para tradução:
 
 ```yaml
 en:
   hello: "Hello world"
 ```
 
-Isso significa que, na localidade `:en`, a chave _hello_ será mapeada para a string _Hello world_. Cada *string* dentro do Rails é internacionalizada dessa maneira. Consulte, por exemplo, as mensagens de validação do Active Model no arquivo [activemodel/lib/active_model/locale/en.yml](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/locale/en.yml) ou os formatos de hora e data no arquivo [`activesupport/lib/active_support/locale/en.yml`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml). Você pode usar YAML ou hashes Ruby padrão para armazenar traduções no *backend* padrão (Simple).
+Isso significa que, na localidade `:en`, a chave _hello_ será mapeada para a _string_ _Hello world_. Cada _string_ dentro do Rails é internacionalizada dessa maneira. Consulte, por exemplo, as mensagens de validação do Active Model no arquivo [activemodel/lib/active_model/locale/en.yml](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/locale/en.yml) ou os formatos de hora e data no arquivo [`activesupport/lib/active_support/locale/en.yml`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml). Você pode usar YAML ou hashes Ruby padrão para armazenar traduções no *backend* (Simple) padrão.
 
 A biblioteca I18n usará o **inglês** como **localidade padrão**. Ou seja, se uma localidade diferente não estiver configurada, `:en` será usada para procurar traduções.
 
@@ -110,7 +110,7 @@ NOTE: A biblioteca I18n adota uma **abordagem pragmática** para as chaves de lo
 
 O **caminho de carregamento de traduções* (`I18n.load_path`) é um *array* de caminhos para arquivos que serão carregados automaticamente. Configurar este caminho permite a personalização da estrutura do diretório de traduções e do esquema de nomeação de arquivos.
 
-NOTE: O *backend* carrega essas traduções de forma lenta quando uma tradução é consultada pela primeira vez. Esse *backend* pode ser trocado por outro mesmo depois que as traduções já foram anunciadas.
+NOTE: O *backend* carrega essas traduções de forma preguiçosa (*lazy-load*) quando uma tradução é consultada pela primeira vez. Esse *backend* pode ser trocado por outro mesmo depois que as traduções já foram anunciadas.
 
 Você pode alterar a localidade padrão, bem como configurar os caminhos de carregamento de traduções em `config/application.rb` da seguinte forma:
 
@@ -118,6 +118,7 @@ Você pode alterar a localidade padrão, bem como configurar os caminhos de carr
 config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
 config.i18n.default_locale = :de
 ```
+
 O caminho de carregamento deve ser especificado antes de qualquer consulta de tradução. Para alterar a localidade padrão a partir de um inicializador em vez de `config/application.rb`:
 
 ```ruby
@@ -133,11 +134,11 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
-Note que anexar diretamente a `I18n.load_path` em vez de à configuração i18n da aplicação _não_ substituirá traduções de gems externas.
+Note que anexar diretamente a `I18n.load_path` em vez de à configuração i18n da aplicação **não** substituirá traduções de _gems_ externas.
 
 ### Gerenciando a Localidade entre Requisições
 
-Uma aplicação localizada provavelmente precisará oferecer suporte a várias localidades. Para isso, a localidade deve ser definida no início de cada requisição para que todas as *strings* sejam traduzidas usando a localidade desejada durante a vida útil dessa requisição.
+Uma aplicação localizada provavelmente precisará oferecer suporte a várias localidades. Para isso, a localidade deve ser definida no início de cada requisição para que todas as _strings_ sejam traduzidas usando a localidade desejada durante a vida útil dessa requisição.
 
 A localidade padrão é usada para todas as traduções, a menos que `I18n.locale=` ou `I18n.with_locale` seja usado.
 
@@ -160,9 +161,9 @@ A localidade pode ser definida de várias maneiras diferentes.
 
 #### Definindo a Localidade a partir do Nome do Domínio
 
-Uma opção que você tem é definir a localidade a partir do nome de domínio onde sua aplicação está em execução. Por exemplo, queremos que `www.example.com` carregue a localidade em inglês (ou padrão) e `www.example.es` carregue a localidade em espanhol. Assim, o nome de _domínio de nível superior_ é usado para a definição da localidade. Isso tem várias vantagens:
+Uma opção que você tem é definir a localidade a partir do nome de domínio onde sua aplicação está em execução. Por exemplo, queremos que `www.example.com` carregue a localidade em inglês (ou padrão) e `www.example.es` carregue a localidade em espanhol. Assim, o nome de **domínio de nível superior** é usado para a definição da localidade. Isso tem várias vantagens:
 
-* A localidade é uma parte _óbvia_ da URL.
+* A localidade é uma parte **óbvia** da URL.
 * As pessoas compreendem intuitivamente em qual idioma o conteúdo será exibido.
 * É muito trivial de implementar no Rails.
 * Os motores de busca parecem gostar de conteúdo em diferentes idiomas em domínios diferentes e interligados.
@@ -201,6 +202,7 @@ def extract_locale_from_subdomain
   I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
+
 Se sua aplicação incluir um menu de troca de idioma, você terá algo assim:
 
 ```ruby
@@ -217,7 +219,7 @@ A maneira mais comum de definir (e passar) o idioma seria incluí-lo nos parâme
 
 Essa abordagem compartilha quase o mesmo conjunto de vantagens de definir o idioma a partir do nome do domínio, principalmente por ser RESTful e estar em conformidade com o restante da World Wide Web. No entanto, demanda um pouco mais de esforço para ser implementada.
 
-Obter o idioma de `params` e defini-lo de acordo não é difícil; incluí-lo em cada URL e assim **passá-lo por meio das solicitações é**. Incluir uma opção explícita em cada URL, por exemplo, `link_to(books_url(locale: I18n.locale))`, seria tedioso e provavelmente impossível, é claro.
+Obter o idioma de `params` e defini-lo de acordo não é difícil; incluí-lo em cada URL e assim **passá-lo por meio da requisição é**. Incluir uma opção explícita em cada URL, por exemplo, `link_to(books_url(locale: I18n.locale))`, seria tedioso e provavelmente impossível, é claro.
 
 O Rails contém infraestrutura para "centralizar decisões dinâmicas sobre os URLs" em seu [`ApplicationController#default_url_options`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-default_url_options), que é útil precisamente nesse cenário: ele nos permite definir "padrões" para [`url_for`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/UrlFor.html#method-i-url_for) e métodos auxiliares dependentes dele (implementando/substituindo `default_url_options`).
 
@@ -229,12 +231,12 @@ def default_url_options
   { locale: I18n.locale }
 end
 ```
-Todo método auxiliar dependente de `url_for` (por exemplo, auxiliares para rotas nomeadas como `root_path` ou `root_url`, rotas de recursos como `books_path` ou `books_url`, etc.) agora incluirá **automaticamente o idioma na string de consulta**, como isto: `http://localhost:3001/?locale=ja`.
+
+Todo método auxiliar dependente de `url_for` (por exemplo, auxiliares para rotas nomeadas como `root_path` ou `root_url`, rotas de recursos como `books_path` ou `books_url`, etc.) agora incluirá **automaticamente o idioma na _string_ de consulta**, como isto: `http://localhost:3001/?locale=ja`.
 
 Você pode estar satisfeito com isso. No entanto, impacta a legibilidade das URLs, quando o idioma "pendura" no final de cada URL na sua aplicação. Além disso, do ponto de vista arquitetônico, o idioma geralmente está hierarquicamente acima das outras partes do domínio da aplicação: e as URLs devem refletir isso.
 
 Provavelmente, você quer que as URLs se pareçam com isso: `http://www.example.com/en/books` (que carrega o idioma inglês) e `http://www.example.com/nl/books` (que carrega o idioma holandês). Isso é possível com a estratégia de "sobrepor `default_url_options`" mencionada acima: você só precisa configurar suas rotas com [`scope`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Scoping.html):
-You probably want URLs to look like this: `http://www.example.com/en/books` (which loads the English locale) and `http://www.example.com/nl/books` (which loads the Dutch locale). This is achievable with the "over-riding `default_url_options`" strategy from above: you just have to set up your routes with [`scope`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Scoping.html):
 
 ```ruby
 # config/routes.rb
@@ -245,7 +247,7 @@ end
 
 Agora, quando você chama o método `books_path`, você deve obter `"/en/books"` (para o idioma padrão). Uma URL como `http://localhost:3001/nl/books` deve carregar o idioma holandês e chamadas subsequentes para `books_path` devem retornar `"/nl/books"` (porque o idioma mudou).
 
-CUIDADO. Como o valor de retorno de `default_url_options` é armazenado em cache por solicitação, as URLs em um seletor de idioma não podem ser geradas chamando auxiliares em um _loop_ que define o `I18n.locale` correspondente em cada iteração. Em vez disso, deixe `I18n.locale` intocado e passe uma opção explícita `:locale` para o auxiliar, ou edite `request.original_fullpath`.
+WARNING. Como o valor de retorno de `default_url_options` é armazenado em _cache_ por solicitação, as URLs em um seletor de idioma não podem ser geradas chamando auxiliares em um _loop_ que define o `I18n.locale` correspondente em cada iteração. Em vez disso, deixe `I18n.locale` intocado e passe uma opção explícita `:locale` para o auxiliar, ou edite `request.original_fullpath`.
 
 Se você não deseja forçar o uso de um idioma nas suas rotas, pode usar um escopo de caminho opcional (indicado pelos parênteses) assim:
 
@@ -255,6 +257,7 @@ scope "(:locale)", locale: /en|nl/ do
   resources :books
 end
 ```
+
 Com essa abordagem, você não receberá um `Routing Error` ao acessar seus recursos, como  `http://localhost:3001/books` sem um idioma. Isso é útil quando você deseja usar o idioma padrão quando não especificado.
 
 
@@ -266,9 +269,10 @@ Você provavelmente precisaria mapear URLs como estas:
 # config/routes.rb
 get '/:locale' => 'dashboard#index'
 ```
+
 Tenha um cuidado especial com a **ordem das suas rotas**, para que essa declaração de rota não "anule" outras. (Você pode querer adicioná-la diretamente antes da declaração `root :to`.)
 
-NOTA: Dê uma olhada em várias gems que simplificam o trabalho com rotas:  [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
+NOTE: Dê uma olhada em várias gems que simplificam o trabalho com rotas:  [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
 
 #### Definindo o Idioma a partir das Preferências do Usuário
 
@@ -317,7 +321,7 @@ Em geral, essa abordagem é muito menos confiável do que usar o cabeçalho de i
 
 #### Armazenando o Idioma a partir da Sessão ou *Cookies*
 
-CUIDADO: Você pode ser tentado a armazenar o idioma escolhido em uma _sessão_ ou em um *cookie*. No entanto, **não faça isso**. O idioma deve ser transparente e fazer parte da URL. Dessa forma, você não quebrará as suposições básicas das pessoas sobre a web: se você enviar uma URL a um amigo, eles deveriam ver a mesma página e conteúdo que você. Um termo sofisticado para isso seria que você está sendo [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Leia mais sobre a abordagem RESTful nos [artigos de Stefan Tilkov](https://www.infoq.com/articles/rest-introduction). Às vezes, há exceções a essa regra, e essas são discutidas abaixo.
+WARNING: Você pode ser tentado a armazenar o idioma escolhido em uma _sessão_ ou em um *cookie*. No entanto, **não faça isso**. O idioma deve ser transparente e fazer parte da URL. Dessa forma, você não quebrará as suposições básicas das pessoas sobre a web: se você enviar uma URL a um amigo, eles deveriam ver a mesma página e conteúdo que você. Um termo sofisticado para isso seria que você está sendo [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Leia mais sobre a abordagem RESTful nos [artigos de Stefan Tilkov](https://www.infoq.com/articles/rest-introduction). Às vezes, há exceções a essa regra, e essas são discutidas abaixo.
 
 Internationalization and Localization
 -------------------------------------


### PR DESCRIPTION
Close: https://github.com/campuscode/rails-guides-pt-BR/issues/848

Motivação

Continuar tradução do capítulo sobre I18n.

Tradução do tópico [2 Setup the Rails Application for Internationalization](https://guiarails.com.br/i18n.html#setup-the-rails-application-for-internationalization) da página [API de Internacionalização do Rails (I18n)](https://guiarails.com.br/i18n.html).