### PR TITLE
Tradução I18n > 3. Internationalization and Localization

### DIFF
--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -323,8 +323,9 @@ In general, this approach is far less reliable than using the language header an
 
 WARNING: You may be tempted to store the chosen locale in a _session_ or a *cookie*. However, **do not do this**. The locale should be transparent and a part of the URL. This way you won't break people's basic assumptions about the web itself: if you send a URL to a friend, they should see the same page and content as you. A fancy word for this would be that you're being [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Read more about the RESTful approach in [Stefan Tilkov's articles](https://www.infoq.com/articles/rest-introduction). Sometimes there are exceptions to this rule and those are discussed below.
 
-Internationalization and Localization
--------------------------------------
+
+Internacionalização e Localização
+---------------------------------
 
 OK! Now you've initialized I18n support for your Ruby on Rails application and told it which locale to use and how to preserve it between requests.
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -327,7 +327,7 @@ WARNING: You may be tempted to store the chosen locale in a _session_ or a *cook
 Internacionalização e Localização
 ---------------------------------
 
-OK! Now you've initialized I18n support for your Ruby on Rails application and told it which locale to use and how to preserve it between requests.
+Ok! Agora você inicializou o suporte a I18n para sua aplicação Ruby on Rails e definiu qual localidade usar e como preservá-la entre requisições.
 
 Next we need to _internationalize_ our application by abstracting every locale-specific element. Finally, we need to _localize_ it by providing necessary translations for these abstracts.
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -327,7 +327,7 @@ WARNING: You may be tempted to store the chosen locale in a _session_ or a *cook
 Internacionalização e Localização
 ---------------------------------
 
-Ok! Agora você inicializou o suporte a I18n para sua aplicação Ruby on Rails e definiu qual localidade usar e como preservá-la entre requisições.
+Ok! Agora você inicializou o suporte a I18n para sua aplicação Ruby on Rails, definiu qual localidade usar e como preservá-la entre requisições.
 
 A seguir, precisamos internacionalizar nossa aplicação abstraindo todos os elementos específicos de localidade. Finalmente, precisamos localizá-la fornecendo as traduções necessárias para essas abstrações.
 
@@ -372,7 +372,7 @@ end
 
 ### Abstraindo Código Localizado
 
-Em nosso código, existem duas _strings_ escritas em inglês que serão renderizadas em nossa resposta ("Hello Flash" e "Hello World"). Para internacionalizar esse código, essas _strings_ precisam ser substituídas por chamadas ao auxiliar `#t` do Rails com uma chave apropriada para cada _string_:
+Em nosso código, existem duas *strings* escritas em inglês que serão renderizadas em nossa resposta ("Hello Flash" e "Hello World"). Para internacionalizar esse código, essas *strings* precisam ser substituídas por chamadas ao *helper* `#t` do Rails com uma chave apropriada para cada *string*:
 
 ```ruby
 # app/controllers/home_controller.rb
@@ -389,13 +389,13 @@ end
 <p><%= flash[:notice] %></p>
 ```
 
-Agora, quando essa visão é renderizada, ela mostrará uma mensagem de erro informando que as traduções para as chaves `:hello_world` e `:hello_flash` estão faltando.
+Agora, quando essa *view* é renderizada, ela mostrará uma mensagem de erro informando que as traduções para as chaves `:hello_world` e `:hello_flash` estão faltando.
 
 ![rails i18n demo translation missing](images/i18n/demo_translation_missing.png)
 
-NOTE: O Rails adiciona um método auxiliar `t` (`translate`) às suas visões para que você não precise escrever `I18n.t` o tempo todo. Além disso, esse auxiliar capturará traduções ausentes e envolverá a mensagem de erro resultante em um `<span class="translation_missing">`.
+NOTE: O Rails adiciona um método *helper* `t` (`translate`) às suas *views* para que você não precise escrever `I18n.t` o tempo todo. Além disso, esse *helper* capturará traduções ausentes e envolverá a mensagem de erro resultante em um `<span class="translation_missing">`.
 
-### Fornecendo Traduções para Strings Internacionalizadas
+### Fornecendo Traduções para *Strings* Internacionalizadas
 
 Adicione as traduções ausentes nos arquivos de dicionário de tradução:
 
@@ -413,17 +413,17 @@ pirate:
   hello_flash: Ahoy Flash
 ```
 
-Como a `default_locale` não foi alterada, as traduções usam a localidade `:en e a resposta renderiza as strings em inglês:
+Como a `default_locale` não foi alterada, as traduções usam a localidade `:en` e a resposta renderiza as *strings* em inglês:
 
-![rails i18n demo translated to English](images/i18n/demo_translated_en.png)
+![demonstação rails i18n traduzido para o inglês](images/i18n/demo_translated_en.png)
 
-Se a localidade for definida via URL para a localidade pirata (`http://localhost:3000?locale=pirate`), a resposta renderiza as strings piratas:
+Se a localidade for definida via URL para a localidade pirata (`http://localhost:3000?locale=pirate`), a resposta renderiza as *strings* piratas:
 
-![rails i18n demo translated to pirate](images/i18n/demo_translated_pirate.png)
+![demonstação rails i18n traduzido para piratas](images/i18n/demo_translated_pirate.png)
 
 NOTE: Você precisa reiniciar o servidor quando adicionar novos arquivos de localidade.
 
-Você pode usar arquivos YAML (`.yml`) ou Ruby puro (`.rb`) para armazenar suas traduções no SimpleStore. YAML é a opção preferida entre os desenvolvedores Rails. No entanto, tem uma grande desvantagem. YAML é muito sensível a espaços em branco e caracteres especiais, então a aplicação pode não carregar seu dicionário corretamente. Arquivos Ruby farão sua aplicação travar na primeira solicitação, assim você pode facilmente encontrar o que está errado. (Se você encontrar "problemas estranhos" com dicionários YAML, tente colocar a parte relevante do seu dicionário em um arquivo Ruby.)
+Você pode usar arquivos YAML (`.yml`) ou Ruby puro (`.rb`) para armazenar suas traduções no SimpleStore. YAML é a opção preferida entre os desenvolvedores Rails. No entanto, tem uma grande desvantagem. YAML é muito sensível a espaços em branco e caracteres especiais, então a aplicação pode não carregar seu dicionário corretamente. Arquivos Ruby farão sua aplicação travar na primeira *request*, assim você pode facilmente encontrar o que está errado. (Se você encontrar "problemas estranhos" com dicionários YAML, tente colocar a parte relevante do seu dicionário em um arquivo Ruby.)
 
 Se suas traduções forem armazenadas em arquivos YAML, certas palavras-chave precisam ser colocadas entre aspas. São elas:
 
@@ -458,7 +458,7 @@ I18n.t 'failure.true'  # => Translation Missing
 
 Uma consideração importante para internacionalizar com sucesso uma aplicação é evitar fazer suposições incorretas sobre regras gramaticais ao abstrair código localizado. Regras gramaticais que parecem fundamentais em uma localidade podem não se aplicar em outra.
 
-A abstração inadequada é mostrada no seguinte exemplo, onde suposições são feitas sobre a ordenação das diferentes partes da tradução. Note que o Rails fornece um auxiliar `number_to_currency` para tratar o seguinte caso.
+A abstração inadequada é mostrada no seguinte exemplo, onde suposições são feitas sobre a ordenação das diferentes partes da tradução. Note que o Rails fornece um *helper* `number_to_currency` para tratar o seguinte caso.
 
 ```erb
 <!-- app/views/products/show.html.erb -->
@@ -506,8 +506,7 @@ NOTE: As palavras-chave `default` e `scope` são reservadas e não podem ser usa
 
 ### Adicionando Formatos de Data/Hora
 
-Ok! Agora vamos adicionar um carimbo de data/hora à visualização, para que também possamos demonstrar o recurso de **localização de data/hora**. Para localizar o formato de tempo, você passa o objeto Time para `I18n.l` ou (preferencialmente) usa o auxiliar `#l` do Rails. Você pode escolher um formato passando a opção `:format` - por padrão, o formato `:default` é usado.
-OK! Now let's add a timestamp to the view, so we can demo the **date/time localization** feature as well. To localize the time format you pass the Time object to `I18n.l` or (preferably) use Rails' `#l` helper. You can pick a format by passing the `:format` option - by default the `:default` format is used.
+Ok! Agora vamos adicionar um *timestamp* à *view*, para que também possamos demonstrar o recurso de **localização de data/hora**. Para localizar o formato de tempo, você passa o objeto Time para `I18n.l` ou (preferencialmente) usa o *helper* `#l` do Rails. Você pode escolher um formato passando a opção `:format` - por padrão, o formato `:default` é usado.
 
 ```erb
 <!-- app/views/home/index.html.erb -->
@@ -528,19 +527,19 @@ pirate:
 
 Isso lhe daria:
 
-![rails i18n demo localized time to pirate](images/i18n/demo_localized_pirate.png)
+![demonstração do rails i18n de tempo localizado para piratas](images/i18n/demo_localized_pirate.png)
 
 TIP: Agora você pode precisar adicionar mais formatos de data/hora para fazer o backend I18n funcionar conforme o esperado (pelo menos para a localidade 'pirata'). Claro, há uma grande chance de que alguém já tenha feito todo o trabalho **traduzindo os padrões do Rails para sua localidade**. Veja o [repositório rails-i18n no GitHub](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) para um arquivo de várias localidades. Ao colocar tais arquivos no diretório `config/locales/`, eles estarão automaticamente prontos para uso.
 
 ### Regras de Inflecção para Outras Localidades
 
-O Rails permite que você defina regras de inflexão (como regras de singularização e pluralização) para localidades além do inglês. Em `config/initializers/inflections.rb`, você pode definir essas regras para múltiplas localidades. O inicializador contém um exemplo padrão para especificar regras adicionais para o inglês; siga esse formato para outras localidades conforme achar adequado.
+O Rails permite que você defina regras de inflexão (como regras de singularização e pluralização) para localidades além do inglês. Em `config/initializers/inflections.rb`, você pode definir essas regras para múltiplas localidades. O *initializer* contém um exemplo padrão para especificar regras adicionais para o inglês; siga esse formato para outras localidades conforme achar adequado.
 
-### Visualizações Localizadas
+### *Views* Localizadas
 
-Digamos que você tenha um _BooksController_ na sua aplicação. Sua ação _index_ renderiza conteúdo no template `app/views/books/index.html.erb`. Quando você coloca uma _variante localizada_ deste template: `index.es.html.erb` no mesmo diretório, o Rails renderizará conteúdo neste template, quando a localidade estiver definida como `:es`. Quando a localidade estiver definida como a localidade padrão, a visão genérica `index.es.html.erb` será usada. (Versões futuras do Rails podem trazer esta _localização automágica_ para ativos em `public`, etc.)
+Digamos que você tenha um _BooksController_ na sua aplicação. Sua ação _index_ renderiza conteúdo no *template* `app/views/books/index.html.erb`. Quando você coloca uma _variante localizada_ deste template: `index.es.html.erb` no mesmo diretório, o Rails renderizará conteúdo neste template, quando a localidade estiver definida como `:es`. Quando a localidade estiver definida como a localidade padrão, a visão genérica `index.es.html.erb` será usada. (Versões futuras do Rails podem trazer esta _localização automágica_ para *assets* em `public`, etc.)
 
-Você pode aproveitar esse recurso, por exemplo, ao trabalhar com uma grande quantidade de conteúdo estático, que seria difícil colocar dentro de dicionários YAML ou Ruby. No entanto, lembre-se de que qualquer alteração que você desejar fazer posteriormente no template deve ser propagada para todos eles.
+Você pode aproveitar esse recurso, por exemplo, ao trabalhar com uma grande quantidade de conteúdo estático, que seria difícil colocar dentro de dicionários YAML ou Ruby. No entanto, lembre-se de que qualquer alteração que você desejar fazer posteriormente no *template* deve ser propagada para todos eles.
 
 ### Organização dos Arquivos de Localidade
 
@@ -571,7 +570,7 @@ Por exemplo, o diretório `config/locales` da sua aplicação poderia ter a segu
 |-----en.yml
 ```
 
-Dessa forma, você pode separar nomes de modelos e atributos de modelo do texto dentro das views, e todos os elementos "padrões" (como, por exemplo, os formatos de data e hora). Outros métodos de armazenamento para a biblioteca i18n podem oferecer diferentes formas de realizar essa separação.
+Dessa forma, você pode separar nomes de *models* e atributos de *model* do texto dentro das *views*, e todos os elementos "padrões" (como, por exemplo, os formatos de data e hora). Outros métodos de armazenamento para a biblioteca i18n podem oferecer diferentes formas de realizar essa separação.
 
 NOTE: O mecanismo de carregamento de localidades padrão do Rails não carrega arquivos de localidade em dicionários aninhados, como temos aqui. Portanto, para que isso funcione, devemos explicitamente dizer ao Rails para procurar mais adiante:
 

--- a/pt-BR/i18n.md
+++ b/pt-BR/i18n.md
@@ -329,9 +329,9 @@ Internacionalização e Localização
 
 Ok! Agora você inicializou o suporte a I18n para sua aplicação Ruby on Rails e definiu qual localidade usar e como preservá-la entre requisições.
 
-Next we need to _internationalize_ our application by abstracting every locale-specific element. Finally, we need to _localize_ it by providing necessary translations for these abstracts.
+A seguir, precisamos internacionalizar nossa aplicação abstraindo todos os elementos específicos de localidade. Finalmente, precisamos localizá-la fornecendo as traduções necessárias para essas abstrações.
 
-Given the following example:
+Dado o seguinte exemplo:
 
 ```ruby
 # config/routes.rb
@@ -370,9 +370,9 @@ end
 
 ![rails i18n demo untranslated](images/i18n/demo_untranslated.png)
 
-### Abstracting Localized Code
+### Abstraindo Código Localizado
 
-In our code, there are two strings written in English that will be rendered in our response ("Hello Flash" and "Hello World"). To internationalize this code, these strings need to be replaced by calls to Rails' `#t` helper with an appropriate key for each string:
+Em nosso código, existem duas _strings_ escritas em inglês que serão renderizadas em nossa resposta ("Hello Flash" e "Hello World"). Para internacionalizar esse código, essas _strings_ precisam ser substituídas por chamadas ao auxiliar `#t` do Rails com uma chave apropriada para cada _string_:
 
 ```ruby
 # app/controllers/home_controller.rb
@@ -389,15 +389,15 @@ end
 <p><%= flash[:notice] %></p>
 ```
 
-Now, when this view is rendered, it will show an error message which tells you that the translations for the keys `:hello_world` and `:hello_flash` are missing.
+Agora, quando essa visão é renderizada, ela mostrará uma mensagem de erro informando que as traduções para as chaves `:hello_world` e `:hello_flash` estão faltando.
 
 ![rails i18n demo translation missing](images/i18n/demo_translation_missing.png)
 
-NOTE: Rails adds a `t` (`translate`) helper method to your views so that you do not need to spell out `I18n.t` all the time. Additionally this helper will catch missing translations and wrap the resulting error message into a `<span class="translation_missing">`.
+NOTE: O Rails adiciona um método auxiliar `t` (`translate`) às suas visões para que você não precise escrever `I18n.t` o tempo todo. Além disso, esse auxiliar capturará traduções ausentes e envolverá a mensagem de erro resultante em um `<span class="translation_missing">`.
 
-### Providing Translations for Internationalized Strings
+### Fornecendo Traduções para Strings Internacionalizadas
 
-Add the missing translations into the translation dictionary files:
+Adicione as traduções ausentes nos arquivos de dicionário de tradução:
 
 ```yaml
 # config/locales/en.yml
@@ -413,24 +413,24 @@ pirate:
   hello_flash: Ahoy Flash
 ```
 
-Because the `default_locale` hasn't changed, translations use the `:en` locale and the response renders the english strings:
+Como a `default_locale` não foi alterada, as traduções usam a localidade `:en e a resposta renderiza as strings em inglês:
 
 ![rails i18n demo translated to English](images/i18n/demo_translated_en.png)
 
-If the locale is set via the URL to the pirate locale (`http://localhost:3000?locale=pirate`), the response renders the pirate strings:
+Se a localidade for definida via URL para a localidade pirata (`http://localhost:3000?locale=pirate`), a resposta renderiza as strings piratas:
 
 ![rails i18n demo translated to pirate](images/i18n/demo_translated_pirate.png)
 
-NOTE: You need to restart the server when you add new locale files.
+NOTE: Você precisa reiniciar o servidor quando adicionar novos arquivos de localidade.
 
-You may use YAML (`.yml`) or plain Ruby (`.rb`) files for storing your translations in SimpleStore. YAML is the preferred option among Rails developers. However, it has one big disadvantage. YAML is very sensitive to whitespace and special characters, so the application may not load your dictionary properly. Ruby files will crash your application on first request, so you may easily find what's wrong. (If you encounter any "weird issues" with YAML dictionaries, try putting the relevant portion of your dictionary into a Ruby file.)
+Você pode usar arquivos YAML (`.yml`) ou Ruby puro (`.rb`) para armazenar suas traduções no SimpleStore. YAML é a opção preferida entre os desenvolvedores Rails. No entanto, tem uma grande desvantagem. YAML é muito sensível a espaços em branco e caracteres especiais, então a aplicação pode não carregar seu dicionário corretamente. Arquivos Ruby farão sua aplicação travar na primeira solicitação, assim você pode facilmente encontrar o que está errado. (Se você encontrar "problemas estranhos" com dicionários YAML, tente colocar a parte relevante do seu dicionário em um arquivo Ruby.)
 
-If your translations are stored in YAML files, certain keys must be escaped. They are:
+Se suas traduções forem armazenadas em arquivos YAML, certas palavras-chave precisam ser colocadas entre aspas. São elas:
 
 * true, on, yes
 * false, off, no
 
-Examples:
+Exemplos:
 
 ```yaml
 # config/locales/en.yml
@@ -454,16 +454,11 @@ I18n.t 'failure.off'   # => Translation Missing
 I18n.t 'failure.true'  # => Translation Missing
 ```
 
-### Passing Variables to Translations
+### Passando Variáveis para Traduções
 
-One key consideration for successfully internationalizing an application is to
-avoid making incorrect assumptions about grammar rules when abstracting localized
-code. Grammar rules that seem fundamental in one locale may not hold true in
-another one.
+Uma consideração importante para internacionalizar com sucesso uma aplicação é evitar fazer suposições incorretas sobre regras gramaticais ao abstrair código localizado. Regras gramaticais que parecem fundamentais em uma localidade podem não se aplicar em outra.
 
-Improper abstraction is shown in the following example, where assumptions are
-made about the ordering of the different parts of the translation. Note that Rails
-provides a `number_to_currency` helper to handle the following case.
+A abstração inadequada é mostrada no seguinte exemplo, onde suposições são feitas sobre a ordenação das diferentes partes da tradução. Note que o Rails fornece um auxiliar `number_to_currency` para tratar o seguinte caso.
 
 ```erb
 <!-- app/views/products/show.html.erb -->
@@ -482,14 +477,11 @@ es:
   currency: "€"
 ```
 
-If the product's price is 10 then the proper translation for Spanish is "10 €"
-instead of "€10" but the abstraction cannot give it.
+Se o preço do produto for 10, então a tradução correta para o espanhol é "10 €" em vez de "€10", mas a abstração não permite isso.
 
-To create proper abstraction, the I18n gem ships with a feature called variable
-interpolation that allows you to use variables in translation definitions and
-pass the values for these variables to the translation method.
+Para criar uma abstração adequada, a gem I18n oferece um recurso chamado interpolação de variáveis que permite usar variáveis nas definições de tradução e passar os valores dessas variáveis para o método de tradução.
 
-Proper abstraction is shown in the following example:
+A abstração adequada é mostrada no seguinte exemplo:
 
 ```erb
 <!-- app/views/products/show.html.erb -->
@@ -508,16 +500,13 @@ es:
   product_price: "%{price} €"
 ```
 
-All grammatical and punctuation decisions are made in the definition itself, so
-the abstraction can give a proper translation.
+Todas as decisões gramaticais e de pontuação são feitas na definição em si, então a abstração pode fornecer uma tradução adequada.
 
-NOTE: The `default` and `scope` keywords are reserved and can't be used as
-variable names. If used, an `I18n::ReservedInterpolationKey` exception is raised.
-If a translation expects an interpolation variable, but this has not been passed
-to `#translate`, an `I18n::MissingInterpolationArgument` exception is raised.
+NOTE: As palavras-chave `default` e `scope` são reservadas e não podem ser usadas como nomes de variáveis. Se utilizadas, uma exceção `I18n::ReservedInterpolationKey` é gerada. Se uma tradução espera uma variável de interpolação, mas esta não foi passada para `#translate`, uma exceção `I18n::MissingInterpolationArgument` é gerada.
 
-### Adding Date/Time Formats
+### Adicionando Formatos de Data/Hora
 
+Ok! Agora vamos adicionar um carimbo de data/hora à visualização, para que também possamos demonstrar o recurso de **localização de data/hora**. Para localizar o formato de tempo, você passa o objeto Time para `I18n.l` ou (preferencialmente) usa o auxiliar `#l` do Rails. Você pode escolher um formato passando a opção `:format` - por padrão, o formato `:default` é usado.
 OK! Now let's add a timestamp to the view, so we can demo the **date/time localization** feature as well. To localize the time format you pass the Time object to `I18n.l` or (preferably) use Rails' `#l` helper. You can pick a format by passing the `:format` option - by default the `:default` format is used.
 
 ```erb
@@ -527,7 +516,7 @@ OK! Now let's add a timestamp to the view, so we can demo the **date/time locali
 <p><%= l Time.now, format: :short %></p>
 ```
 
-And in our pirate translations file let's add a time format (it's already there in Rails' defaults for English):
+E no nosso arquivo de traduções pirata, vamos adicionar um formato de tempo (já está nos padrões do Rails para inglês):
 
 ```yaml
 # config/locales/pirate.yml
@@ -537,30 +526,27 @@ pirate:
       short: "arrrround %H'ish"
 ```
 
-So that would give you:
+Isso lhe daria:
 
 ![rails i18n demo localized time to pirate](images/i18n/demo_localized_pirate.png)
 
-TIP: Right now you might need to add some more date/time formats in order to make the I18n backend work as expected (at least for the 'pirate' locale). Of course, there's a great chance that somebody already did all the work by **translating Rails' defaults for your locale**. See the [rails-i18n repository at GitHub](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) for an archive of various locale files. When you put such file(s) in `config/locales/` directory, they will automatically be ready for use.
+TIP: Agora você pode precisar adicionar mais formatos de data/hora para fazer o backend I18n funcionar conforme o esperado (pelo menos para a localidade 'pirata'). Claro, há uma grande chance de que alguém já tenha feito todo o trabalho **traduzindo os padrões do Rails para sua localidade**. Veja o [repositório rails-i18n no GitHub](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) para um arquivo de várias localidades. Ao colocar tais arquivos no diretório `config/locales/`, eles estarão automaticamente prontos para uso.
 
-### Inflection Rules for Other Locales
+### Regras de Inflecção para Outras Localidades
 
-Rails allows you to define inflection rules (such as rules for singularization and pluralization) for locales other than English. In `config/initializers/inflections.rb`, you can define these rules for multiple locales. The initializer contains a default example for specifying additional rules for English; follow that format for other locales as you see fit.
+O Rails permite que você defina regras de inflexão (como regras de singularização e pluralização) para localidades além do inglês. Em `config/initializers/inflections.rb`, você pode definir essas regras para múltiplas localidades. O inicializador contém um exemplo padrão para especificar regras adicionais para o inglês; siga esse formato para outras localidades conforme achar adequado.
 
-### Localized Views
+### Visualizações Localizadas
 
-Let's say you have a _BooksController_ in your application. Your _index_ action renders content in `app/views/books/index.html.erb` template. When you put a _localized variant_ of this template: `index.es.html.erb` in the same directory, Rails will render content in this template, when the locale is set to `:es`. When the locale is set to the default locale, the generic `index.html.erb` view will be used. (Future Rails versions may well bring this _automagic_ localization to assets in `public`, etc.)
+Digamos que você tenha um _BooksController_ na sua aplicação. Sua ação _index_ renderiza conteúdo no template `app/views/books/index.html.erb`. Quando você coloca uma _variante localizada_ deste template: `index.es.html.erb` no mesmo diretório, o Rails renderizará conteúdo neste template, quando a localidade estiver definida como `:es`. Quando a localidade estiver definida como a localidade padrão, a visão genérica `index.es.html.erb` será usada. (Versões futuras do Rails podem trazer esta _localização automágica_ para ativos em `public`, etc.)
 
-You can make use of this feature, e.g. when working with a large amount of static content, which would be clumsy to put inside YAML or Ruby dictionaries. Bear in mind, though, that any change you would like to do later to the template must be propagated to all of them.
+Você pode aproveitar esse recurso, por exemplo, ao trabalhar com uma grande quantidade de conteúdo estático, que seria difícil colocar dentro de dicionários YAML ou Ruby. No entanto, lembre-se de que qualquer alteração que você desejar fazer posteriormente no template deve ser propagada para todos eles.
 
-### Organization of Locale Files
+### Organização dos Arquivos de Localidade
 
-When you are using the default SimpleStore shipped with the i18n library,
-dictionaries are stored in plain-text files on the disk. Putting translations
-for all parts of your application in one file per locale could be hard to
-manage. You can store these files in a hierarchy which makes sense to you.
+Quando você está usando o SimpleStore padrão fornecido com a biblioteca i18n, os dicionários são armazenados em arquivos de texto simples no disco. Colocar traduções para todas as partes da sua aplicação em um arquivo por localidade pode ser difícil de gerenciar. Você pode armazenar esses arquivos em uma hierarquia que faça sentido para você.
 
-For example, your `config/locales` directory could look like this:
+Por exemplo, o diretório `config/locales` da sua aplicação poderia ter a seguinte estrutura:
 
 ```
 |-defaults
@@ -585,9 +571,9 @@ For example, your `config/locales` directory could look like this:
 |-----en.yml
 ```
 
-This way, you can separate model and model attribute names from text inside views, and all of this from the "defaults" (e.g. date and time formats). Other stores for the i18n library could provide different means of such separation.
+Dessa forma, você pode separar nomes de modelos e atributos de modelo do texto dentro das views, e todos os elementos "padrões" (como, por exemplo, os formatos de data e hora). Outros métodos de armazenamento para a biblioteca i18n podem oferecer diferentes formas de realizar essa separação.
 
-NOTE: The default locale loading mechanism in Rails does not load locale files in nested dictionaries, like we have here. So, for this to work, we must explicitly tell Rails to look further:
+NOTE: O mecanismo de carregamento de localidades padrão do Rails não carrega arquivos de localidade em dicionários aninhados, como temos aqui. Portanto, para que isso funcione, devemos explicitamente dizer ao Rails para procurar mais adiante:
 
 ```ruby
 # config/application.rb


### PR DESCRIPTION
Close: https://github.com/campuscode/rails-guides-pt-BR/issues/851

Motivação

Continuar tradução do capítulo sobre I18n.

Tradução do tópico [3 Internationalization and Localization](https://guiarails.com.br/i18n.html#internationalization-and-localization) para a página [API de Internacionalização do Rails (I18n)](https://guiarails.com.br/i18n.html).
